### PR TITLE
Bootstrap local training API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+
+# Local python packaging
+pip-wheel-metadata/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch==2.4.1
+numpy

--- a/rinker/__init__.py
+++ b/rinker/__init__.py
@@ -1,0 +1,4 @@
+"""Rinker – a minimal RL fine-tuning framework stub."""
+from .api.service_client import ServiceClient
+
+__all__ = ["ServiceClient"]

--- a/rinker/api/__init__.py
+++ b/rinker/api/__init__.py
@@ -1,0 +1,13 @@
+"""Public API for interacting with the Rinker service."""
+from .sampling_client import SamplingClient, SamplingResult
+from .service_client import ServiceCapabilities, ServiceClient
+from .training_client import ForwardBackwardResponse, TrainingClient
+
+__all__ = [
+    "SamplingClient",
+    "SamplingResult",
+    "ServiceCapabilities",
+    "ServiceClient",
+    "ForwardBackwardResponse",
+    "TrainingClient",
+]

--- a/rinker/api/sampling_client.py
+++ b/rinker/api/sampling_client.py
@@ -1,0 +1,90 @@
+"""Sampling client for synchronous inference."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+import torch.nn.functional as F
+
+from ..core.types import ModelInput, SamplingParams
+from ..utils.tokenizer import SimpleTokenizer
+
+
+@dataclass
+class SamplingResult:
+    text: str
+    token_ids: List[int]
+    logprobs: List[float]
+
+
+class SamplingClient:
+    def __init__(self, *, model: torch.nn.Module, tokenizer: SimpleTokenizer) -> None:
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = torch.device("cpu")
+        self._model.to(self._device)
+        self._model.eval()
+
+    def sample(
+        self,
+        model_input: ModelInput,
+        sampling_params: SamplingParams,
+        num_samples: int = 1,
+    ) -> List[SamplingResult]:
+        prompt_tokens = model_input.token_chunks[0].to(self._device)
+        results: List[SamplingResult] = []
+        for _ in range(num_samples):
+            token_ids = prompt_tokens.clone().tolist()
+            generated_logprobs: List[float] = []
+            for _ in range(sampling_params.max_new_tokens):
+                input_tensor = torch.tensor(token_ids, dtype=torch.long, device=self._device).unsqueeze(0)
+                logits = self._model(input_tensor)[0, -1]
+                next_token, logprob = self._select_token(logits, sampling_params)
+                token_ids.append(int(next_token))
+                generated_logprobs.append(float(logprob))
+                decoded = self._tokenizer.decode(token_ids[len(prompt_tokens) :])
+                if self._should_stop(decoded, sampling_params):
+                    break
+            text = self._tokenizer.decode(token_ids)
+            results.append(SamplingResult(text=text, token_ids=token_ids, logprobs=generated_logprobs))
+        return results
+
+    def _select_token(self, logits: torch.Tensor, params: SamplingParams) -> tuple[int, float]:
+        if params.temperature <= 0:
+            raise ValueError("Temperature must be > 0")
+        logits = logits / params.temperature
+        probs = F.softmax(logits, dim=-1)
+        if params.top_k is not None:
+            topk = min(params.top_k, probs.numel())
+            values, indices = torch.topk(probs, topk)
+            probs = values / values.sum()
+            token_candidates = indices
+        else:
+            token_candidates = torch.arange(probs.numel(), device=probs.device)
+        if params.top_p is not None:
+            sorted_probs, sorted_idx = torch.sort(probs, descending=True)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            mask = cumulative <= params.top_p
+            mask[..., 0] = True
+            filtered_probs = torch.where(mask, sorted_probs, torch.zeros_like(sorted_probs))
+            if filtered_probs.sum() == 0:
+                filtered_probs = sorted_probs
+            filtered_probs = filtered_probs / filtered_probs.sum()
+            choice = torch.multinomial(filtered_probs, 1).item()
+            token_id = token_candidates[sorted_idx[choice]].item()
+            logprob = torch.log(filtered_probs[choice] + 1e-12).item()
+            return token_id, logprob
+        else:
+            sampled_index = torch.multinomial(probs, 1).item()
+            token_id = token_candidates[sampled_index].item()
+            logprob = torch.log(probs[sampled_index] + 1e-12).item()
+            return token_id, logprob
+
+    def _should_stop(self, decoded: str, params: SamplingParams) -> bool:
+        if not params.stop_sequences:
+            return False
+        return any(decoded.endswith(stop) for stop in params.stop_sequences)
+
+
+__all__ = ["SamplingClient", "SamplingResult"]

--- a/rinker/api/service_client.py
+++ b/rinker/api/service_client.py
@@ -1,0 +1,34 @@
+"""Entry point for users interacting with the local training runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ..core.engine import SimpleLanguageModel
+from ..utils.tokenizer import SimpleTokenizer
+from .training_client import TrainingClient
+
+
+@dataclass
+class ServiceCapabilities:
+    base_models: List[str]
+
+
+class ServiceClient:
+    """Factory for training and sampling clients."""
+
+    def __init__(self) -> None:
+        self._tokenizer = SimpleTokenizer()
+        self._base_models = ["tiny-char-gpt"]
+
+    def get_server_capabilities(self) -> ServiceCapabilities:
+        return ServiceCapabilities(base_models=list(self._base_models))
+
+    def create_lora_training_client(self, base_model: str, rank: int, **_) -> TrainingClient:
+        if base_model not in self._base_models:
+            raise ValueError(f"Unsupported base model: {base_model}")
+        model = SimpleLanguageModel(self._tokenizer.vocab_size)
+        return TrainingClient(model=model, tokenizer=self._tokenizer)
+
+
+__all__ = ["ServiceClient", "ServiceCapabilities"]

--- a/rinker/api/training_client.py
+++ b/rinker/api/training_client.py
@@ -1,0 +1,48 @@
+"""Training client implementing the synchronous week 1 API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+
+from ..core import engine
+from ..core.types import AdamParams, Datum
+from ..utils.futures import ImmediateFuture
+from ..utils.tokenizer import SimpleTokenizer
+from .sampling_client import SamplingClient
+
+
+@dataclass
+class ForwardBackwardResponse:
+    loss: float
+
+
+class TrainingClient:
+    def __init__(self, *, model: torch.nn.Module, tokenizer: SimpleTokenizer) -> None:
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = torch.device("cpu")
+        self._model.to(self._device)
+        self._optimiser: torch.optim.Optimizer | None = None
+
+    @property
+    def tokenizer(self) -> SimpleTokenizer:
+        return self._tokenizer
+
+    def forward_backward(self, batch: Sequence[Datum], loss_fn: str = "cross_entropy") -> ImmediateFuture[ForwardBackwardResponse]:
+        result = engine.forward_backward(self._model, batch, loss_fn, device=self._device)
+        return ImmediateFuture(ForwardBackwardResponse(loss=result.loss))
+
+    def optim_step(self, params: AdamParams) -> ImmediateFuture[dict]:
+        self._optimiser = engine.ensure_adam(self._model, self._optimiser, params)
+        metrics = engine.optim_step(self._model, self._optimiser)
+        return ImmediateFuture(metrics)
+
+    def save_weights_and_get_sampling_client(self, name: str) -> SamplingClient:
+        model_copy = engine.SimpleLanguageModel(self._tokenizer.vocab_size)
+        model_copy.load_state_dict(self._model.state_dict())
+        return SamplingClient(model=model_copy, tokenizer=self._tokenizer)
+
+
+__all__ = ["TrainingClient", "ForwardBackwardResponse"]

--- a/rinker/core/__init__.py
+++ b/rinker/core/__init__.py
@@ -1,0 +1,17 @@
+"""Core utilities (engine, types, and losses)."""
+from . import losses
+from .engine import SimpleLanguageModel, ensure_adam, forward_backward, optim_step
+from .types import AdamParams, Datum, ModelInput, SamplingParams, TensorDict
+
+__all__ = [
+    "losses",
+    "SimpleLanguageModel",
+    "ensure_adam",
+    "forward_backward",
+    "optim_step",
+    "AdamParams",
+    "Datum",
+    "ModelInput",
+    "SamplingParams",
+    "TensorDict",
+]

--- a/rinker/core/engine.py
+++ b/rinker/core/engine.py
@@ -1,0 +1,116 @@
+"""Training utilities for the local single GPU/CPU backend."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Sequence
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from . import losses
+from .types import AdamParams, Datum
+
+
+LOSS_REGISTRY: Dict[str, Callable[..., Dict[str, torch.Tensor]]] = {
+    "cross_entropy": losses.cross_entropy,
+    "importance_sampling": losses.importance_sampling,
+    "ppo": losses.ppo,
+}
+
+
+class SimpleLanguageModel(nn.Module):
+    """A minimal autoregressive model suitable for quick CPU experiments."""
+
+    def __init__(self, vocab_size: int, hidden_size: int = 128):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden_size)
+        self.rnn = nn.GRU(hidden_size, hidden_size, batch_first=True)
+        self.ln = nn.LayerNorm(hidden_size)
+        self.head = nn.Linear(hidden_size, vocab_size)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        embeds = self.embedding(input_ids)
+        outputs, _ = self.rnn(embeds)
+        outputs = self.ln(outputs)
+        logits = self.head(outputs)
+        return logits
+
+
+@dataclass
+class ForwardBackwardResult:
+    loss: float
+    details: Dict[str, torch.Tensor]
+
+
+def forward_backward(
+    model: nn.Module,
+    batch: Sequence[Datum],
+    loss_name: str,
+    device: torch.device,
+) -> ForwardBackwardResult:
+    """Runs a forward/backward pass for the provided batch."""
+
+    if loss_name not in LOSS_REGISTRY:
+        raise ValueError(f"Unknown loss '{loss_name}'")
+
+    model.train()
+    inputs = torch.cat([datum.model_input.to_batch(device) for datum in batch], dim=0)
+    targets = torch.cat([datum.loss_fn_inputs["targets"].unsqueeze(0).to(device) for datum in batch], dim=0)
+    weights = None
+    if "weights" in batch[0].loss_fn_inputs:
+        weights = torch.cat([datum.loss_fn_inputs["weights"].unsqueeze(0).to(device) for datum in batch], dim=0)
+
+    logits = model(inputs)
+    loss_fn = LOSS_REGISTRY[loss_name]
+    result = loss_fn(logits, targets=targets, weights=weights)
+    loss = result["loss"]
+    loss.backward()
+    return ForwardBackwardResult(loss=float(loss.detach().cpu()), details=result)
+
+
+def optim_step(
+    model: nn.Module,
+    optimiser: torch.optim.Optimizer,
+) -> Dict[str, float]:
+    """Applies an optimisation step and zeros gradients."""
+
+    optimiser.step()
+    optimiser.zero_grad(set_to_none=True)
+    return {"grad_norm": _total_grad_norm(model)}
+
+
+def ensure_adam(
+    model: nn.Module,
+    optimiser: torch.optim.Optimizer | None,
+    params: AdamParams,
+) -> torch.optim.Optimizer:
+    if optimiser is not None:
+        return optimiser
+    betas = tuple(params.betas)
+    optimiser = torch.optim.Adam(
+        model.parameters(),
+        lr=params.lr,
+        betas=betas,  # type: ignore[arg-type]
+        eps=params.eps,
+        weight_decay=params.weight_decay,
+    )
+    return optimiser
+
+
+def _total_grad_norm(model: nn.Module) -> float:
+    total = 0.0
+    for param in model.parameters():
+        if param.grad is None:
+            continue
+        total += param.grad.detach().data.norm(2).item() ** 2
+    return total ** 0.5
+
+
+__all__ = [
+    "SimpleLanguageModel",
+    "ForwardBackwardResult",
+    "forward_backward",
+    "optim_step",
+    "ensure_adam",
+]

--- a/rinker/core/losses.py
+++ b/rinker/core/losses.py
@@ -1,0 +1,42 @@
+"""Loss functions used by the training engine."""
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+import torch.nn.functional as F
+
+def cross_entropy(logits: torch.Tensor, *, targets: torch.Tensor, weights: torch.Tensor | None = None) -> Dict[str, torch.Tensor]:
+    """Token-level cross entropy with sum reduction.
+
+    Args:
+        logits: Tensor of shape (batch, seq_len, vocab).
+        targets: Tensor of shape (batch, seq_len) with target token ids.
+        weights: Optional tensor of shape (batch, seq_len) providing per-token
+            weights. When omitted, every target contributes equally.
+    Returns:
+        Dictionary with the scalar loss (for backward) and per-token log-probs.
+    """
+
+    log_probs = F.log_softmax(logits, dim=-1)
+    target_log_probs = log_probs.gather(-1, targets.unsqueeze(-1)).squeeze(-1)
+    if weights is None:
+        weights = torch.ones_like(target_log_probs, dtype=log_probs.dtype)
+    weights = weights.to(log_probs.dtype)
+    loss = -(target_log_probs * weights).sum()
+    return {
+        "loss": loss,
+        "target_log_probs": target_log_probs.detach(),
+        "weights": weights.detach(),
+    }
+
+
+def importance_sampling(*args, **kwargs):  # pragma: no cover - stub for week 1
+    raise NotImplementedError("Importance sampling loss will arrive in week 2")
+
+
+def ppo(*args, **kwargs):  # pragma: no cover - stub for week 1
+    raise NotImplementedError("PPO loss will arrive in week 2")
+
+
+__all__ = ["cross_entropy", "importance_sampling", "ppo"]

--- a/rinker/core/rendering/base.py
+++ b/rinker/core/rendering/base.py
@@ -1,0 +1,27 @@
+"""Renderer abstractions for chat style prompting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass
+class ChatMessage:
+    role: str
+    content: str
+
+
+class Renderer:
+    """Base renderer for chat-oriented models."""
+
+    def build_generation_prompt(self, messages: Sequence[ChatMessage]) -> str:
+        raise NotImplementedError
+
+    def get_stop_sequences(self) -> List[str]:
+        return []
+
+    def parse_response(self, text: str) -> str:
+        return text
+
+
+__all__ = ["Renderer", "ChatMessage"]

--- a/rinker/core/rendering/llama.py
+++ b/rinker/core/rendering/llama.py
@@ -1,0 +1,34 @@
+"""LLaMA style chat renderer."""
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from .base import ChatMessage, Renderer
+
+
+class LlamaRenderer(Renderer):
+    BOS = "<s>"
+    EOS = "</s>"
+
+    def build_generation_prompt(self, messages: Sequence[ChatMessage]) -> str:
+        prompt_parts: List[str] = [self.BOS]
+        for message in messages:
+            if message.role == "system":
+                prompt_parts.append(f"<<SYS>>\n{message.content}\n<</SYS>>\n\n")
+            elif message.role == "user":
+                prompt_parts.append(f"[INST] {message.content} [/INST]")
+            elif message.role == "assistant":
+                prompt_parts.append(f" {message.content} {self.EOS}")
+            else:
+                raise ValueError(f"Unsupported role: {message.role}")
+        prompt_parts.append(" ")
+        return "".join(prompt_parts)
+
+    def get_stop_sequences(self) -> List[str]:
+        return [self.EOS]
+
+    def parse_response(self, text: str) -> str:
+        return text.split(self.EOS, 1)[0].strip()
+
+
+__all__ = ["LlamaRenderer"]

--- a/rinker/core/rendering/qwen.py
+++ b/rinker/core/rendering/qwen.py
@@ -1,0 +1,36 @@
+"""Qwen style chat renderer."""
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from .base import ChatMessage, Renderer
+
+
+class QwenRenderer(Renderer):
+    SYSTEM_PREFIX = "<|im_start|>system\n"
+    USER_PREFIX = "<|im_start|>user\n"
+    ASSISTANT_PREFIX = "<|im_start|>assistant\n"
+    SUFFIX = "<|im_end|>"
+
+    def build_generation_prompt(self, messages: Sequence[ChatMessage]) -> str:
+        prompt_parts: List[str] = []
+        for message in messages:
+            if message.role == "system":
+                prompt_parts.append(f"{self.SYSTEM_PREFIX}{message.content}{self.SUFFIX}\n")
+            elif message.role == "user":
+                prompt_parts.append(f"{self.USER_PREFIX}{message.content}{self.SUFFIX}\n")
+            elif message.role == "assistant":
+                prompt_parts.append(f"{self.ASSISTANT_PREFIX}{message.content}{self.SUFFIX}\n")
+            else:
+                raise ValueError(f"Unsupported role: {message.role}")
+        prompt_parts.append(f"{self.ASSISTANT_PREFIX}")
+        return "".join(prompt_parts)
+
+    def get_stop_sequences(self) -> List[str]:
+        return [self.SUFFIX]
+
+    def parse_response(self, text: str) -> str:
+        return text.split(self.SUFFIX, 1)[0]
+
+
+__all__ = ["QwenRenderer"]

--- a/rinker/core/types.py
+++ b/rinker/core/types.py
@@ -1,0 +1,72 @@
+"""Core data structures for the Rinker training and sampling API."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Mapping, MutableMapping, Optional
+
+import torch
+
+
+TensorDict = MutableMapping[str, torch.Tensor]
+
+
+@dataclass
+class ModelInput:
+    """Represents the tokenised input to the model.
+
+    The public API mirrors Tinker where model inputs are provided as chunks of
+    token ids (to allow prefix packing in the future). For the week 1
+    implementation we simply expect a single chunk, but the abstraction keeps
+    the surface compatible with the longer term design.
+    """
+
+    token_chunks: List[torch.Tensor]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_batch(self, device: Optional[torch.device] = None) -> torch.Tensor:
+        """Stacks the token chunks into a single tensor for model consumption."""
+
+        if len(self.token_chunks) != 1:
+            raise ValueError("Week 1 implementation expects exactly one chunk per datum")
+        tokens = self.token_chunks[0]
+        if device is not None:
+            tokens = tokens.to(device)
+        return tokens.unsqueeze(0)
+
+
+@dataclass
+class Datum:
+    """A training datum consisting of model input and loss specific tensors."""
+
+    model_input: ModelInput
+    loss_fn_inputs: TensorDict
+
+
+@dataclass
+class AdamParams:
+    """Hyper-parameters for the Adam optimiser."""
+
+    lr: float = 1e-3
+    betas: Iterable[float] = (0.9, 0.999)
+    eps: float = 1e-8
+    weight_decay: float = 0.0
+
+
+@dataclass
+class SamplingParams:
+    """Parameters controlling autoregressive sampling."""
+
+    max_new_tokens: int = 32
+    temperature: float = 1.0
+    top_k: Optional[int] = None
+    top_p: Optional[float] = None
+    stop_sequences: Optional[List[str]] = None
+
+
+__all__ = [
+    "TensorDict",
+    "ModelInput",
+    "Datum",
+    "AdamParams",
+    "SamplingParams",
+]

--- a/rinker/examples/sl_basic.py
+++ b/rinker/examples/sl_basic.py
@@ -1,0 +1,66 @@
+"""Minimal supervised fine-tuning loop using the synchronous API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import torch
+
+if __package__ is None or __package__ == "":
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from rinker.api.service_client import ServiceClient
+from rinker.core.types import AdamParams, Datum, ModelInput, SamplingParams
+from rinker.utils.seeding import seed_everything
+
+
+@dataclass
+class ToyDataset:
+    prompts: List[str]
+    completions: List[str]
+
+    def __iter__(self):
+        yield from zip(self.prompts, self.completions)
+
+
+if __name__ == "__main__":
+    seed_everything(42)
+
+    dataset = ToyDataset(
+        prompts=["hello" for _ in range(16)],
+        completions=[" world" for _ in range(16)],
+    )
+
+    service = ServiceClient()
+    capabilities = service.get_server_capabilities()
+    print("Available models:", capabilities.base_models)
+    training = service.create_lora_training_client(capabilities.base_models[0], rank=4)
+
+    tokenizer = training.tokenizer
+
+    batch: List[Datum] = []
+    for prompt, completion in dataset:
+        full_text = prompt + completion
+        token_ids = torch.tensor(tokenizer.encode(full_text), dtype=torch.long)
+        inputs = token_ids[:-1]
+        targets = token_ids[1:]
+        model_input = ModelInput(token_chunks=[inputs])
+        loss_inputs = {
+            "targets": targets,
+            "weights": torch.ones_like(targets, dtype=torch.float32),
+        }
+        batch.append(Datum(model_input=model_input, loss_fn_inputs=loss_inputs))
+
+    future = training.forward_backward(batch, loss_fn="cross_entropy")
+    print("Loss:", future.result().loss)
+    training.optim_step(AdamParams(lr=5e-3)).result()
+
+    sampler = training.save_weights_and_get_sampling_client("toy")
+    sampling_params = SamplingParams(max_new_tokens=12, temperature=0.8, stop_sequences=["\n"])
+    sample = sampler.sample(batch[0].model_input, sampling_params=sampling_params, num_samples=1)[0]
+    print("Sample:", sample.text)

--- a/rinker/tests/conftest.py
+++ b/rinker/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/rinker/tests/test_losses.py
+++ b/rinker/tests/test_losses.py
@@ -1,0 +1,22 @@
+import math
+
+import torch
+
+from rinker.core.losses import cross_entropy
+
+
+def test_cross_entropy_matches_manual_sum():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 3, 5)
+    targets = torch.tensor([[1, 2, 3], [0, 4, 1]])
+    weights = torch.tensor([[1.0, 0.5, 0.0], [0.2, 1.0, 1.0]])
+
+    result = cross_entropy(logits, targets=targets, weights=weights)
+
+    log_probs = torch.log_softmax(logits, dim=-1)
+    manual = 0.0
+    for b in range(logits.size(0)):
+        for t in range(logits.size(1)):
+            manual -= weights[b, t] * log_probs[b, t, targets[b, t]]
+
+    assert torch.isclose(result["loss"], manual)

--- a/rinker/tests/test_sampling.py
+++ b/rinker/tests/test_sampling.py
@@ -1,0 +1,36 @@
+import torch
+
+from rinker.api.sampling_client import SamplingClient
+from rinker.core.types import ModelInput, SamplingParams
+from rinker.utils.tokenizer import SimpleTokenizer
+
+
+class ConstantModel(torch.nn.Module):
+    def __init__(self, vocab_size: int, token_id: int):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.token_id = token_id
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        batch, seq_len = input_ids.shape
+        logits = torch.zeros(batch, seq_len, self.vocab_size)
+        logits[..., self.token_id] = 10.0
+        return logits
+
+
+def test_sampling_respects_stop_sequences():
+    tokenizer = SimpleTokenizer()
+    stop_token = "."
+    stop_id = tokenizer.vocab[stop_token]
+    model = ConstantModel(tokenizer.vocab_size, stop_id)
+    client = SamplingClient(model=model, tokenizer=tokenizer)
+
+    prompt = "Hello"
+    prompt_tokens = torch.tensor(tokenizer.encode(prompt), dtype=torch.long)
+    model_input = ModelInput(token_chunks=[prompt_tokens])
+    params = SamplingParams(max_new_tokens=5, temperature=1.0, stop_sequences=[stop_token])
+
+    result = client.sample(model_input, params, num_samples=1)[0]
+
+    assert result.text.endswith(stop_token)
+    assert len(result.logprobs) == 1

--- a/rinker/utils/__init__.py
+++ b/rinker/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for tokenisation, RNG seeding and futures."""
+from .futures import ImmediateFuture
+from .seeding import seed_everything
+from .tokenizer import SimpleTokenizer
+
+__all__ = ["ImmediateFuture", "seed_everything", "SimpleTokenizer"]

--- a/rinker/utils/futures.py
+++ b/rinker/utils/futures.py
@@ -1,0 +1,19 @@
+"""Minimal future-like wrapper used by the synchronous API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class ImmediateFuture(Generic[T]):
+    value: T
+
+    def result(self) -> T:
+        return self.value
+
+
+__all__ = ["ImmediateFuture"]

--- a/rinker/utils/seeding.py
+++ b/rinker/utils/seeding.py
@@ -1,0 +1,21 @@
+"""Utility helpers to seed Python and PyTorch RNGs."""
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def seed_everything(seed: int, *, deterministic: bool = False) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():  # pragma: no cover - GPU not present in CI
+        torch.cuda.manual_seed_all(seed)
+    if deterministic:
+        torch.use_deterministic_algorithms(True)
+
+
+__all__ = ["seed_everything"]

--- a/rinker/utils/tokenizer.py
+++ b/rinker/utils/tokenizer.py
@@ -1,0 +1,38 @@
+"""A very small character level tokenizer used for the examples and tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class SimpleTokenizer:
+    """Character-level tokenizer compatible with our toy models."""
+
+    unk_token: str = "<unk>"
+    pad_token: str = "<pad>"
+    vocab: Dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.vocab:
+            # initialise with printable ASCII characters
+            import string
+
+            characters = list(string.printable)
+            self.vocab = {ch: idx for idx, ch in enumerate(characters)}
+            self.vocab[self.unk_token] = len(self.vocab)
+            self.vocab[self.pad_token] = len(self.vocab)
+        self.inv_vocab = {idx: token for token, idx in self.vocab.items()}
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.vocab)
+
+    def encode(self, text: str) -> List[int]:
+        return [self.vocab.get(ch, self.vocab[self.unk_token]) for ch in text]
+
+    def decode(self, token_ids: Iterable[int]) -> str:
+        return "".join(self.inv_vocab.get(idx, self.unk_token) for idx in token_ids)
+
+
+__all__ = ["SimpleTokenizer"]


### PR DESCRIPTION
## Summary
- scaffold the rinker package with a synchronous ServiceClient/TrainingClient/SamplingClient API
- implement core engine, model, rendering utilities, and a character tokenizer to support local CPU training
- add an SL quickstart example plus unit tests for cross-entropy maths and sampling stop sequences

## Testing
- `pytest`
- `python rinker/examples/sl_basic.py`


------
https://chatgpt.com/codex/tasks/task_e_68df6b1478508332804ae1b5aae97756