### PR TITLE
Add PPO and IS losses with diagnostics and RL example

### DIFF
--- a/rinker/core/__init__.py
+++ b/rinker/core/__init__.py
@@ -1,13 +1,24 @@
 """Core utilities (engine, types, and losses)."""
 from . import losses
-from .engine import SimpleLanguageModel, ensure_adam, forward_backward, optim_step
+from .engine import (
+    SimpleLanguageModel,
+    CustomLossOutputs,
+    ForwardBackwardOutput,
+    ensure_adam,
+    forward_backward,
+    forward_backward_custom,
+    optim_step,
+)
 from .types import AdamParams, Datum, ModelInput, SamplingParams, TensorDict
 
 __all__ = [
     "losses",
     "SimpleLanguageModel",
+    "CustomLossOutputs",
+    "ForwardBackwardOutput",
     "ensure_adam",
     "forward_backward",
+    "forward_backward_custom",
     "optim_step",
     "AdamParams",
     "Datum",

--- a/rinker/core/engine.py
+++ b/rinker/core/engine.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Sequence
+from typing import Callable, Dict, Mapping, MutableMapping, Sequence
 
 import torch
 import torch.nn as nn
@@ -38,9 +38,18 @@ class SimpleLanguageModel(nn.Module):
 
 
 @dataclass
-class ForwardBackwardResult:
+class ForwardBackwardOutput:
     loss: float
-    details: Dict[str, torch.Tensor]
+    metrics: Dict[str, float]
+    loss_fn_outputs: Dict[str, torch.Tensor]
+
+
+@dataclass
+class CustomLossOutputs:
+    loss: torch.Tensor
+    log_prob_grads: torch.Tensor
+    metrics: Mapping[str, float | torch.Tensor] | None = None
+    loss_fn_outputs: Mapping[str, torch.Tensor] | None = None
 
 
 def forward_backward(
@@ -48,7 +57,7 @@ def forward_backward(
     batch: Sequence[Datum],
     loss_name: str,
     device: torch.device,
-) -> ForwardBackwardResult:
+) -> ForwardBackwardOutput:
     """Runs a forward/backward pass for the provided batch."""
 
     if loss_name not in LOSS_REGISTRY:
@@ -56,17 +65,146 @@ def forward_backward(
 
     model.train()
     inputs = torch.cat([datum.model_input.to_batch(device) for datum in batch], dim=0)
-    targets = torch.cat([datum.loss_fn_inputs["targets"].unsqueeze(0).to(device) for datum in batch], dim=0)
-    weights = None
-    if "weights" in batch[0].loss_fn_inputs:
-        weights = torch.cat([datum.loss_fn_inputs["weights"].unsqueeze(0).to(device) for datum in batch], dim=0)
-
     logits = model(inputs)
     loss_fn = LOSS_REGISTRY[loss_name]
-    result = loss_fn(logits, targets=targets, weights=weights)
+
+    tensor_inputs = _gather_tensor_inputs(batch, device)
+    kwargs: MutableMapping[str, torch.Tensor | float] = dict(tensor_inputs)
+    if "targets" in kwargs:
+        kwargs["targets"] = kwargs["targets"].long()
+    if "target_tokens" in kwargs:
+        kwargs["target_tokens"] = kwargs["target_tokens"].long()
+
+    if loss_name == "ppo":
+        clip_value = batch[0].loss_fn_inputs.get("clip_epsilon", 0.2)
+        if isinstance(clip_value, torch.Tensor):
+            clip_value = float(clip_value.item())
+        kwargs["clip_epsilon"] = float(clip_value)
+
+    result = loss_fn(logits, **kwargs)
     loss = result["loss"]
     loss.backward()
-    return ForwardBackwardResult(loss=float(loss.detach().cpu()), details=result)
+
+    metrics = _build_metrics(result)
+    loss_fn_outputs = _detach_loss_outputs(result)
+
+    return ForwardBackwardOutput(
+        loss=float(loss.detach().cpu()),
+        metrics=metrics,
+        loss_fn_outputs=loss_fn_outputs,
+    )
+
+
+def forward_backward_custom(
+    model: nn.Module,
+    batch: Sequence[Datum],
+    custom_fn: Callable[[Sequence[Datum], torch.Tensor], CustomLossOutputs],
+    device: torch.device,
+) -> ForwardBackwardOutput:
+    """Runs a forward/backward pass using a custom loss defined on log-probs."""
+
+    model.train()
+    inputs = torch.cat([datum.model_input.to_batch(device) for datum in batch], dim=0)
+    logits = model(inputs)
+
+    tensor_inputs = _gather_tensor_inputs(batch, device)
+    if "target_tokens" not in tensor_inputs:
+        raise ValueError("Custom loss requires 'target_tokens' in loss_fn_inputs")
+
+    target_tokens = tensor_inputs["target_tokens"].long()
+    log_probs = F.log_softmax(logits, dim=-1)
+    target_log_probs = log_probs.gather(-1, target_tokens.unsqueeze(-1)).squeeze(-1)
+
+    custom_outputs = custom_fn(batch, target_log_probs.detach())
+    if not isinstance(custom_outputs, CustomLossOutputs):
+        raise TypeError("Custom loss function must return CustomLossOutputs")
+
+    log_prob_grads = custom_outputs.log_prob_grads.to(target_log_probs.device)
+    surrogate = (log_prob_grads * target_log_probs).sum()
+    surrogate.backward()
+
+    loss_value = custom_outputs.loss
+    metric_inputs: Dict[str, torch.Tensor] = {
+        "target_log_probs": target_log_probs.detach(),
+    }
+    if "sampling_logprobs" in tensor_inputs:
+        metric_inputs["sampling_logprobs"] = tensor_inputs["sampling_logprobs"].detach()
+    metrics = _build_metrics(metric_inputs)
+
+    if custom_outputs.metrics:
+        for key, value in custom_outputs.metrics.items():
+            if isinstance(value, torch.Tensor):
+                metrics[key] = float(value.detach().cpu())
+            else:
+                metrics[key] = float(value)
+
+    loss_fn_outputs = {
+        "target_log_probs": target_log_probs.detach().cpu(),
+    }
+    if "sampling_logprobs" in tensor_inputs:
+        loss_fn_outputs["sampling_logprobs"] = tensor_inputs["sampling_logprobs"].detach().cpu()
+    if "advantages" in tensor_inputs:
+        loss_fn_outputs["advantages"] = tensor_inputs["advantages"].detach().cpu()
+    if custom_outputs.loss_fn_outputs:
+        for key, value in custom_outputs.loss_fn_outputs.items():
+            if isinstance(value, torch.Tensor):
+                loss_fn_outputs[key] = value.detach().cpu()
+
+    return ForwardBackwardOutput(
+        loss=float(loss_value.detach().cpu()),
+        metrics=metrics,
+        loss_fn_outputs=loss_fn_outputs,
+    )
+
+
+def _gather_tensor_inputs(batch: Sequence[Datum], device: torch.device) -> Dict[str, torch.Tensor]:
+    tensor_keys = set()
+    for datum in batch:
+        for key, value in datum.loss_fn_inputs.items():
+            if isinstance(value, torch.Tensor):
+                tensor_keys.add(key)
+
+    stacked: Dict[str, torch.Tensor] = {}
+    for key in tensor_keys:
+        tensors = []
+        for datum in batch:
+            if key not in datum.loss_fn_inputs:
+                raise KeyError(f"Missing required tensor '{key}' in datum")
+            value = datum.loss_fn_inputs[key]
+            if not isinstance(value, torch.Tensor):
+                raise TypeError(f"Expected tensor for key '{key}' but received {type(value)!r}")
+            tensor = value.to(device)
+            tensor = tensor.unsqueeze(0)
+            tensors.append(tensor)
+        stacked[key] = torch.cat(tensors, dim=0)
+    return stacked
+
+
+def _build_metrics(loss_outputs: Mapping[str, torch.Tensor]) -> Dict[str, float]:
+    metrics: Dict[str, float] = {}
+    if "target_log_probs" in loss_outputs and "sampling_logprobs" in loss_outputs:
+        target = loss_outputs["target_log_probs"].detach()
+        sampling = loss_outputs["sampling_logprobs"].detach()
+        log_ratio = target - sampling
+        ratio = torch.exp(log_ratio)
+        kl_qp = (sampling - target).mean()
+        kl_pq = (ratio * log_ratio).mean()
+        metrics["kl_q||p"] = float(kl_qp.detach().cpu())
+        metrics["kl_p||q"] = float(kl_pq.detach().cpu())
+    if "clip_fraction" in loss_outputs:
+        clip_fraction = loss_outputs["clip_fraction"].detach()
+        metrics["clip_fraction"] = float(clip_fraction.mean().cpu())
+    return metrics
+
+
+def _detach_loss_outputs(result: Mapping[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    outputs: Dict[str, torch.Tensor] = {}
+    for key, value in result.items():
+        if key == "loss":
+            continue
+        if isinstance(value, torch.Tensor):
+            outputs[key] = value.detach().cpu()
+    return outputs
 
 
 def optim_step(
@@ -109,8 +247,10 @@ def _total_grad_norm(model: nn.Module) -> float:
 
 __all__ = [
     "SimpleLanguageModel",
-    "ForwardBackwardResult",
+    "ForwardBackwardOutput",
     "forward_backward",
+    "forward_backward_custom",
+    "CustomLossOutputs",
     "optim_step",
     "ensure_adam",
 ]

--- a/rinker/core/losses.py
+++ b/rinker/core/losses.py
@@ -31,12 +31,98 @@ def cross_entropy(logits: torch.Tensor, *, targets: torch.Tensor, weights: torch
     }
 
 
-def importance_sampling(*args, **kwargs):  # pragma: no cover - stub for week 1
-    raise NotImplementedError("Importance sampling loss will arrive in week 2")
+def importance_sampling(
+    logits: torch.Tensor,
+    *,
+    target_tokens: torch.Tensor,
+    sampling_logprobs: torch.Tensor,
+    advantages: torch.Tensor,
+) -> Dict[str, torch.Tensor]:
+    """Token-level importance sampling / REINFORCE objective.
+
+    Args:
+        logits: Tensor of shape ``(batch, seq_len, vocab)``.
+        target_tokens: Tokens whose log-probabilities are evaluated. Shape
+            ``(batch, seq_len)``.
+        sampling_logprobs: Log-probabilities produced by the behaviour policy
+            that generated ``target_tokens``. Same shape as ``target_tokens``.
+        advantages: Pre-computed advantages per token. Same shape as
+            ``target_tokens``.
+
+    Returns:
+        Dictionary containing the scalar loss used for ``backward`` and
+        diagnostics such as the per-token log-probabilities and ratios.
+    """
+
+    log_probs = F.log_softmax(logits, dim=-1)
+    target_log_probs = log_probs.gather(-1, target_tokens.unsqueeze(-1)).squeeze(-1)
+    sampling_logprobs = sampling_logprobs.to(target_log_probs.dtype)
+    advantages = advantages.to(target_log_probs.dtype)
+
+    log_ratio = target_log_probs - sampling_logprobs
+    ratio = torch.exp(log_ratio)
+    loss = -(ratio * advantages).sum()
+
+    return {
+        "loss": loss,
+        "target_log_probs": target_log_probs.detach(),
+        "sampling_logprobs": sampling_logprobs.detach(),
+        "advantages": advantages.detach(),
+        "ratio": ratio.detach(),
+    }
 
 
-def ppo(*args, **kwargs):  # pragma: no cover - stub for week 1
-    raise NotImplementedError("PPO loss will arrive in week 2")
+def ppo(
+    logits: torch.Tensor,
+    *,
+    target_tokens: torch.Tensor,
+    sampling_logprobs: torch.Tensor,
+    advantages: torch.Tensor,
+    clip_epsilon: float = 0.2,
+) -> Dict[str, torch.Tensor]:
+    """Token-level PPO clipped objective.
+
+    Args:
+        logits: Tensor of shape ``(batch, seq_len, vocab)``.
+        target_tokens: Tokens whose log-probabilities are evaluated. Shape
+            ``(batch, seq_len)``.
+        sampling_logprobs: Behaviour policy log-probabilities. Same shape as
+            ``target_tokens``.
+        advantages: Advantages corresponding to each token. Same shape as
+            ``target_tokens``.
+        clip_epsilon: PPO clipping parameter (default ``0.2``).
+
+    Returns:
+        Dictionary containing the scalar loss and diagnostics including
+        per-token ratios and clipping statistics.
+    """
+
+    log_probs = F.log_softmax(logits, dim=-1)
+    target_log_probs = log_probs.gather(-1, target_tokens.unsqueeze(-1)).squeeze(-1)
+    sampling_logprobs = sampling_logprobs.to(target_log_probs.dtype)
+    advantages = advantages.to(target_log_probs.dtype)
+
+    log_ratio = target_log_probs - sampling_logprobs
+    ratio = torch.exp(log_ratio)
+    clipped_ratio = torch.clamp(ratio, 1.0 - clip_epsilon, 1.0 + clip_epsilon)
+
+    unclipped_objective = ratio * advantages
+    clipped_objective = clipped_ratio * advantages
+    objective = torch.minimum(unclipped_objective, clipped_objective)
+    loss = -objective.sum()
+
+    clip_mask = torch.logical_or(ratio > (1.0 + clip_epsilon), ratio < (1.0 - clip_epsilon))
+    clip_fraction = clip_mask.float().mean()
+
+    return {
+        "loss": loss,
+        "target_log_probs": target_log_probs.detach(),
+        "sampling_logprobs": sampling_logprobs.detach(),
+        "advantages": advantages.detach(),
+        "ratio": ratio.detach(),
+        "clipped_ratio": clipped_ratio.detach(),
+        "clip_fraction": clip_fraction.detach(),
+    }
 
 
 __all__ = ["cross_entropy", "importance_sampling", "ppo"]

--- a/rinker/examples/rl_basic.py
+++ b/rinker/examples/rl_basic.py
@@ -1,0 +1,152 @@
+"""Toy PPO/IS reinforcement learning loop demonstrating rising rewards."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import torch
+
+if __package__ is None or __package__ == "":
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from rinker.api.service_client import ServiceClient
+from rinker.api.training_client import ForwardBackwardResponse
+from rinker.core.types import AdamParams, Datum, ModelInput, SamplingParams
+from rinker.utils.seeding import seed_everything
+
+
+@dataclass
+class PromptSpec:
+    prompt: str
+    answer: str
+
+
+def build_batch(
+    tokenizer,
+    sampler,
+    specs: Sequence[PromptSpec],
+    *,
+    group_size: int,
+    clip_epsilon: float,
+) -> Tuple[List[Datum], float]:
+    batch: List[Datum] = []
+    total_reward = 0.0
+    total_samples = 0
+
+    sampling_params = SamplingParams(max_new_tokens=1, temperature=0.8)
+
+    for spec in specs:
+        prompt_tokens = torch.tensor(tokenizer.encode(spec.prompt), dtype=torch.long)
+        model_input = ModelInput(token_chunks=[prompt_tokens])
+        samples = sampler.sample(model_input, sampling_params=sampling_params, num_samples=group_size)
+
+        group: List[Tuple[float, Datum, int]] = []
+        for sample in samples:
+            completion = sample.text[len(spec.prompt) :].strip()
+            reward = 1.0 if completion.startswith(spec.answer) else 0.0
+            total_reward += reward
+            total_samples += 1
+
+            token_ids = torch.tensor(sample.token_ids, dtype=torch.long)
+            inputs = token_ids[:-1]
+            targets = token_ids[1:]
+            sampling_logprobs = torch.zeros_like(targets, dtype=torch.float32)
+            completion_start = len(prompt_tokens) - 1
+            if sample.logprobs:
+                completion_logprobs = torch.tensor(sample.logprobs, dtype=torch.float32)
+                sampling_logprobs[completion_start : completion_start + completion_logprobs.numel()] = completion_logprobs
+
+            advantages = torch.zeros_like(targets, dtype=torch.float32)
+            loss_inputs: Dict[str, object] = {
+                "target_tokens": targets,
+                "sampling_logprobs": sampling_logprobs,
+                "advantages": advantages,
+                "clip_epsilon": clip_epsilon,
+            }
+            datum = Datum(model_input=ModelInput(token_chunks=[inputs]), loss_fn_inputs=loss_inputs)
+            group.append((reward, datum, completion_start))
+
+        if not group:
+            continue
+
+        rewards = torch.tensor([entry[0] for entry in group], dtype=torch.float32)
+        centred = rewards - rewards.mean()
+        for centred_advantage, (_, datum, completion_start) in zip(centred, group):
+            advantages_tensor = datum.loss_fn_inputs["advantages"]
+            assert isinstance(advantages_tensor, torch.Tensor)
+            advantages_tensor[completion_start:] = centred_advantage
+            batch.append(datum)
+
+    avg_reward = total_reward / max(total_samples, 1)
+    return batch, avg_reward
+
+
+def run_loop(
+    loss_name: str,
+    *,
+    specs: Sequence[PromptSpec],
+    iterations: int,
+    group_size: int = 4,
+) -> List[ForwardBackwardResponse]:
+    service = ServiceClient()
+    base_model = service.get_server_capabilities().base_models[0]
+    training = service.create_lora_training_client(base_model, rank=4)
+    tokenizer = training.tokenizer
+
+    history: List[ForwardBackwardResponse] = []
+    for step in range(iterations):
+        sampler = training.save_weights_and_get_sampling_client(f"{loss_name}-step-{step}")
+        batch, avg_reward = build_batch(
+            tokenizer,
+            sampler,
+            specs,
+            group_size=group_size,
+            clip_epsilon=0.2,
+        )
+        if not batch:
+            break
+
+        fb = training.forward_backward(batch, loss_fn=loss_name).result()
+        training.optim_step(AdamParams(lr=5e-3)).result()
+        history.append(fb)
+
+        kl_old_new = fb.metrics.get("kl_q||p", 0.0)
+        kl_new_old = fb.metrics.get("kl_p||q", 0.0)
+        print(
+            f"[{loss_name}] step={step:02d} reward={avg_reward:.3f} "
+            f"loss={fb.loss:.3f} kl_q||p={kl_old_new:.4f} kl_p||q={kl_new_old:.4f}"
+        )
+
+    return history
+
+
+if __name__ == "__main__":
+    seed_everything(1234)
+
+    prompts = [
+        PromptSpec(prompt="1+1=", answer="2"),
+        PromptSpec(prompt="2+2=", answer="4"),
+        PromptSpec(prompt="3+3=", answer="6"),
+        PromptSpec(prompt="1+2=", answer="3"),
+    ]
+
+    print("Running PPO training loop")
+    ppo_history = run_loop("ppo", specs=prompts, iterations=12)
+
+    print("\nRunning importance sampling training loop")
+    is_history = run_loop("importance_sampling", specs=prompts, iterations=12)
+
+    print("\nFinal PPO reward metrics:")
+    for idx, fb in enumerate(ppo_history[-3:]):
+        step = len(ppo_history) - len(ppo_history[-3:]) + idx
+        print(f"  step {step}: loss={fb.loss:.3f} metrics={fb.metrics}")
+
+    print("\nFinal IS reward metrics:")
+    for idx, fb in enumerate(is_history[-3:]):
+        step = len(is_history) - len(is_history[-3:]) + idx
+        print(f"  step {step}: loss={fb.loss:.3f} metrics={fb.metrics}")

--- a/rinker/tests/test_losses.py
+++ b/rinker/tests/test_losses.py
@@ -2,7 +2,7 @@ import math
 
 import torch
 
-from rinker.core.losses import cross_entropy
+from rinker.core.losses import cross_entropy, importance_sampling, ppo
 
 
 def test_cross_entropy_matches_manual_sum():
@@ -20,3 +20,68 @@ def test_cross_entropy_matches_manual_sum():
             manual -= weights[b, t] * log_probs[b, t, targets[b, t]]
 
     assert torch.isclose(result["loss"], manual)
+
+
+def test_importance_sampling_matches_reinforce_when_on_policy():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 3, 5, requires_grad=True)
+    target_tokens = torch.randint(0, 5, (2, 3))
+    with torch.no_grad():
+        log_probs = torch.log_softmax(logits, dim=-1)
+        sampling_logprobs = log_probs.gather(-1, target_tokens.unsqueeze(-1)).squeeze(-1)
+    advantages = torch.randn(2, 3)
+
+    result = importance_sampling(
+        logits,
+        target_tokens=target_tokens,
+        sampling_logprobs=sampling_logprobs,
+        advantages=advantages,
+    )
+
+    expected = -(advantages.to(logits.dtype)).sum()
+    assert torch.isclose(result["loss"], expected)
+    assert torch.allclose(result["ratio"], torch.ones_like(result["ratio"]))
+
+
+def test_ppo_clipping_behaviour_positive_advantage():
+    logits = torch.zeros(1, 1, 2, requires_grad=True)
+    target_tokens = torch.tensor([[0]])
+    with torch.no_grad():
+        current_logprob = torch.log_softmax(logits, dim=-1)[0, 0, 0]
+        sampling_logprob = current_logprob - math.log(1.5)
+    sampling = torch.full((1, 1), float(sampling_logprob))
+    advantages = torch.ones(1, 1)
+
+    result = ppo(
+        logits,
+        target_tokens=target_tokens,
+        sampling_logprobs=sampling,
+        advantages=advantages,
+        clip_epsilon=0.2,
+    )
+
+    expected_loss = -(1.2 * advantages).sum()
+    assert torch.isclose(result["loss"], expected_loss, atol=1e-6)
+    assert torch.isclose(result["clip_fraction"], torch.tensor(1.0))
+
+
+def test_ppo_clipping_behaviour_negative_advantage():
+    logits = torch.zeros(1, 1, 2, requires_grad=True)
+    target_tokens = torch.tensor([[0]])
+    with torch.no_grad():
+        current_logprob = torch.log_softmax(logits, dim=-1)[0, 0, 0]
+        sampling_logprob = current_logprob + math.log(2.0)
+    sampling = torch.full((1, 1), float(sampling_logprob))
+    advantages = -torch.ones(1, 1)
+
+    result = ppo(
+        logits,
+        target_tokens=target_tokens,
+        sampling_logprobs=sampling,
+        advantages=advantages,
+        clip_epsilon=0.2,
+    )
+
+    expected_loss = -(0.8 * advantages).sum()
+    assert torch.isclose(result["loss"], expected_loss, atol=1e-6)
+    assert torch.isclose(result["clip_fraction"], torch.tensor(1.0))


### PR DESCRIPTION
## Summary
- implement token-level importance sampling and PPO losses with ratio diagnostics
- extend the training engine/client to surface per-token logprobs, KL metrics, and a custom forward_backward path
- add unit tests and a toy rl_basic example that runs PPO/IS loops with rising rewards

## Testing
- pytest
- python rinker/examples/rl_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68df6f547f1483329c3093be7398be00