### PR TITLE
Add Ray runtime integration and async training workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch==2.4.1
 numpy
+ray==2.32.0

--- a/rinker/examples/rl_loop_ray.py
+++ b/rinker/examples/rl_loop_ray.py
@@ -1,0 +1,171 @@
+"""End-to-end PPO loop running on Ray actors."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import ray
+import torch
+
+if __package__ is None or __package__ == "":
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+from rinker.api.service_client import ServiceClient
+from rinker.api.training_client import ForwardBackwardResponse
+from rinker.core.types import AdamParams, Datum, ModelInput, SamplingParams
+from rinker.ray_runtime import RayRuntimeConfig
+from rinker.utils.seeding import seed_everything
+
+
+def addition_reward(prompt: str, completion: str, target: str) -> float:
+    return 1.0 if completion.strip().startswith(target) else 0.0
+
+
+@dataclass
+class PromptSpec:
+    prompt: str
+    answer: str
+
+
+def build_datums(
+    tokenizer,
+    prompt: str,
+    sample_text: str,
+    logprobs: Sequence[float],
+    clip_epsilon: float,
+) -> Datum:
+    token_ids = torch.tensor(tokenizer.encode(sample_text), dtype=torch.long)
+    inputs = token_ids[:-1]
+    targets = token_ids[1:]
+    sampling_logprobs = torch.zeros_like(targets, dtype=torch.float32)
+    prompt_len = len(tokenizer.encode(prompt)) - 1
+    if logprobs:
+        lp_tensor = torch.tensor(logprobs, dtype=torch.float32)
+        sampling_logprobs[prompt_len : prompt_len + lp_tensor.numel()] = lp_tensor
+    datum = Datum(
+        model_input=ModelInput(token_chunks=[inputs]),
+        loss_fn_inputs={
+            "target_tokens": targets,
+            "sampling_logprobs": sampling_logprobs,
+            "advantages": torch.zeros_like(targets, dtype=torch.float32),
+            "clip_epsilon": clip_epsilon,
+        },
+    )
+    return datum
+
+
+def ray_reward_evaluation(
+    actor: ray.ActorHandle,
+    prompt: str,
+    completion: str,
+    target: str,
+) -> float:
+    ref = actor.compute.remote(prompt, completion, target)
+    return float(ray.get(ref))
+
+
+def run_iteration(
+    tokenizer,
+    sampler,
+    reward_actor,
+    specs: Iterable[PromptSpec],
+    *,
+    group_size: int,
+    clip_epsilon: float,
+    sampling_params: SamplingParams,
+) -> tuple[List[Datum], float]:
+    batch: List[Datum] = []
+    rewards: List[float] = []
+
+    for spec in specs:
+        prompt_tokens = torch.tensor(tokenizer.encode(spec.prompt), dtype=torch.long)
+        model_input = ModelInput(token_chunks=[prompt_tokens])
+        samples = sampler.sample(model_input, sampling_params=sampling_params, num_samples=group_size)
+
+        group_rewards: List[float] = []
+        group_data: List[Datum] = []
+        for sample in samples:
+            completion = sample.text[len(spec.prompt) :]
+            reward = ray_reward_evaluation(reward_actor, spec.prompt, completion, spec.answer)
+            group_rewards.append(reward)
+            datum = build_datums(tokenizer, spec.prompt, sample.text, sample.logprobs, clip_epsilon)
+            group_data.append(datum)
+
+        if not group_rewards:
+            continue
+
+        group_tensor = torch.tensor(group_rewards, dtype=torch.float32)
+        centred = group_tensor - group_tensor.mean()
+        for datum, advantage in zip(group_data, centred):
+            advantages_tensor = datum.loss_fn_inputs["advantages"]
+            assert isinstance(advantages_tensor, torch.Tensor)
+            prompt_len = len(tokenizer.encode(spec.prompt)) - 1
+            advantages_tensor[prompt_len:] = advantage
+            batch.append(datum)
+            rewards.append(float(advantage + group_tensor.mean()))
+
+    avg_reward = float(torch.tensor(rewards, dtype=torch.float32).mean()) if rewards else 0.0
+    return batch, avg_reward
+
+
+def run_loop(
+    specs: Sequence[PromptSpec],
+    *,
+    iterations: int,
+    group_size: int,
+) -> List[ForwardBackwardResponse]:
+    config = RayRuntimeConfig(num_sampler_actors=1, max_inflight_rollouts=4)
+    service = ServiceClient(runtime_config=config)
+    base_model = service.get_server_capabilities().base_models[0]
+    training = service.create_lora_training_client(base_model, rank=4)
+    tokenizer = training.tokenizer
+
+    [reward_actor] = training.create_reward_actors([addition_reward])
+
+    sampling_params = SamplingParams(max_new_tokens=4, temperature=0.8)
+    history: List[ForwardBackwardResponse] = []
+
+    for step in range(iterations):
+        sampler = training.save_weights_and_get_sampling_client(f"ppo-step-{step}")
+        batch, avg_reward = run_iteration(
+            tokenizer,
+            sampler,
+            reward_actor,
+            specs,
+            group_size=group_size,
+            clip_epsilon=0.2,
+            sampling_params=sampling_params,
+        )
+        if not batch:
+            break
+
+        fb = training.forward_backward(batch, loss_fn="ppo").result()
+        training.optim_step(AdamParams(lr=5e-3)).result()
+        history.append(fb)
+
+        print(
+            f"[ray] step={step:02d} reward={avg_reward:.3f} loss={fb.loss:.3f} "
+            f"kl_q||p={fb.metrics.get('kl_q||p', 0.0):.4f} "
+            f"kl_p||q={fb.metrics.get('kl_p||q', 0.0):.4f}"
+        )
+
+    ray.shutdown()
+    return history
+
+
+if __name__ == "__main__":
+    seed_everything(2024)
+
+    prompts = [
+        PromptSpec(prompt="1+1=", answer="2"),
+        PromptSpec(prompt="2+2=", answer="4"),
+        PromptSpec(prompt="3+3=", answer="6"),
+        PromptSpec(prompt="4+4=", answer="8"),
+    ]
+
+    run_loop(prompts, iterations=6, group_size=2)

--- a/rinker/ray_runtime/__init__.py
+++ b/rinker/ray_runtime/__init__.py
@@ -1,0 +1,13 @@
+"""Ray runtime integration for Rinker."""
+from .actors import LearnerActor, SamplerActor, RewardActor
+from .config import RayRuntimeConfig
+from .runtime import RayRuntime, SamplingTaskResult
+
+__all__ = [
+    "LearnerActor",
+    "SamplerActor",
+    "RewardActor",
+    "RayRuntime",
+    "RayRuntimeConfig",
+    "SamplingTaskResult",
+]

--- a/rinker/ray_runtime/actors.py
+++ b/rinker/ray_runtime/actors.py
@@ -1,0 +1,194 @@
+"""Ray actors for the learner, sampler, and reward components."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Mapping, Sequence
+
+import torch
+import torch.nn.functional as F
+
+from ..core import engine
+from ..core.types import AdamParams, Datum, ModelInput, SamplingParams
+from ..utils.tokenizer import SimpleTokenizer
+
+try:  # pragma: no cover - ray import is optional in unit tests
+    import ray
+except ImportError as exc:  # pragma: no cover - handled by caller
+    raise RuntimeError(
+        "Ray is required for the ray_runtime components. "
+        "Install with `pip install ray`."
+    ) from exc
+
+
+@dataclass
+class ForwardBackwardPayload:
+    loss: float
+    metrics: Mapping[str, float]
+    loss_fn_outputs: Mapping[str, torch.Tensor]
+
+
+def _resolve_device() -> torch.device:
+    if torch.cuda.is_available():
+        gpu_ids = ray.get_gpu_ids()
+        if gpu_ids:
+            return torch.device("cuda")
+    return torch.device("cpu")
+
+
+@ray.remote
+class LearnerActor:
+    """Learner actor that owns the trainable policy."""
+
+    def __init__(self, vocab_size: int) -> None:
+        self._tokenizer_vocab_size = vocab_size
+        self._device = _resolve_device()
+        self._model = engine.SimpleLanguageModel(vocab_size)
+        self._model.to(self._device)
+        self._optimiser: torch.optim.Optimizer | None = None
+
+    def forward_backward(self, batch: Sequence[Datum], loss_fn: str) -> ForwardBackwardPayload:
+        result = engine.forward_backward(self._model, batch, loss_fn, device=self._device)
+        return ForwardBackwardPayload(
+            loss=result.loss,
+            metrics=result.metrics,
+            loss_fn_outputs=result.loss_fn_outputs,
+        )
+
+    def forward_backward_custom(
+        self,
+        batch: Sequence[Datum],
+        loss_fn: Callable[[Sequence[Datum], torch.Tensor], engine.CustomLossOutputs],
+    ) -> ForwardBackwardPayload:
+        result = engine.forward_backward_custom(self._model, batch, loss_fn, device=self._device)
+        return ForwardBackwardPayload(
+            loss=result.loss,
+            metrics=result.metrics,
+            loss_fn_outputs=result.loss_fn_outputs,
+        )
+
+    def optim_step(self, params: AdamParams) -> Mapping[str, float]:
+        self._optimiser = engine.ensure_adam(self._model, self._optimiser, params)
+        return engine.optim_step(self._model, self._optimiser)
+
+    def get_state(self) -> Mapping[str, torch.Tensor]:
+        state_dict = self._model.state_dict()
+        return {key: value.detach().cpu() for key, value in state_dict.items()}
+
+
+@ray.remote
+class SamplerActor:
+    """Sampler actor responsible for autoregressive generation."""
+
+    def __init__(self, tokenizer: SimpleTokenizer):
+        self._tokenizer = tokenizer
+        self._device = _resolve_device()
+        self._model = engine.SimpleLanguageModel(tokenizer.vocab_size)
+        self._model.to(self._device)
+        self._model.eval()
+        self._stop_sequences: List[str] = []
+
+    def set_weights(self, state_dict: Mapping[str, torch.Tensor]) -> None:
+        self._model.load_state_dict(state_dict)
+        self._model.to(self._device)
+        self._model.eval()
+
+    def generate(
+        self,
+        model_input: ModelInput,
+        sampling_params: SamplingParams,
+        num_samples: int,
+    ) -> List[Mapping[str, object]]:
+        prompt_tokens = self._prepare_prompt(model_input)
+        prompt_tokens = prompt_tokens.to(self._device)
+        outputs: List[Mapping[str, object]] = []
+        stop_sequences = sampling_params.stop_sequences or self._stop_sequences
+
+        for _ in range(num_samples):
+            token_ids = prompt_tokens.clone().tolist()
+            generated_logprobs: List[float] = []
+            for _ in range(sampling_params.max_new_tokens):
+                input_tensor = torch.tensor(token_ids, dtype=torch.long, device=self._device).unsqueeze(0)
+                logits = self._model(input_tensor)[0, -1]
+                token_id, logprob = self._sample_token(logits, sampling_params)
+                token_ids.append(int(token_id))
+                generated_logprobs.append(float(logprob))
+
+                decoded = self._tokenizer.decode(token_ids[len(prompt_tokens) :])
+                if stop_sequences and any(decoded.endswith(stop) for stop in stop_sequences):
+                    break
+
+            text = self._tokenizer.decode(token_ids)
+            parsed = self._parse_response(model_input, text)
+            outputs.append(
+                {
+                    "text": text,
+                    "token_ids": token_ids,
+                    "logprobs": generated_logprobs,
+                    "parsed_response": parsed,
+                }
+            )
+        return outputs
+
+    def _prepare_prompt(self, model_input: ModelInput) -> torch.Tensor:
+        renderer = model_input.metadata.get("renderer") if model_input.metadata else None
+        messages = model_input.metadata.get("messages") if model_input.metadata else None
+        if renderer and messages:
+            prompt_text = renderer.build_generation_prompt(messages)
+            self._stop_sequences = renderer.get_stop_sequences()
+            encoded = self._tokenizer.encode(prompt_text)
+            return torch.tensor(encoded, dtype=torch.long)
+        if not model_input.token_chunks:
+            raise ValueError("ModelInput must contain at least one token chunk")
+        self._stop_sequences = []
+        return model_input.token_chunks[0]
+
+    def _parse_response(self, model_input: ModelInput, text: str) -> str | None:
+        renderer = model_input.metadata.get("renderer") if model_input.metadata else None
+        if renderer:
+            return renderer.parse_response(text)
+        return None
+
+    def _sample_token(self, logits: torch.Tensor, params: SamplingParams) -> tuple[int, float]:
+        if params.temperature <= 0:
+            raise ValueError("Temperature must be > 0")
+        logits = logits / params.temperature
+        probs = F.softmax(logits, dim=-1)
+        if params.top_k is not None:
+            topk = min(params.top_k, probs.numel())
+            values, indices = torch.topk(probs, topk)
+            probs = values / values.sum()
+            token_candidates = indices
+        else:
+            token_candidates = torch.arange(probs.numel(), device=probs.device)
+        if params.top_p is not None:
+            sorted_probs, sorted_idx = torch.sort(probs, descending=True)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            mask = cumulative <= params.top_p
+            if sorted_probs.numel() > 0:
+                mask[..., 0] = True
+            filtered = torch.where(mask, sorted_probs, torch.zeros_like(sorted_probs))
+            if filtered.sum() == 0:
+                filtered = sorted_probs
+            filtered = filtered / filtered.sum()
+            choice = torch.multinomial(filtered, 1).item()
+            token_id = token_candidates[sorted_idx[choice]].item()
+            logprob = torch.log(filtered[choice] + 1e-12).item()
+            return token_id, logprob
+        sampled_index = torch.multinomial(probs, 1).item()
+        token_id = token_candidates[sampled_index].item()
+        logprob = torch.log(probs[sampled_index] + 1e-12).item()
+        return token_id, logprob
+
+
+@ray.remote
+class RewardActor:
+    """Reward actor wrapping a user supplied callable."""
+
+    def __init__(self, reward_fn: Callable[..., float]):
+        self._reward_fn = reward_fn
+
+    def compute(self, *args, **kwargs) -> float:
+        return float(self._reward_fn(*args, **kwargs))
+
+
+__all__ = ["LearnerActor", "SamplerActor", "RewardActor", "ForwardBackwardPayload"]

--- a/rinker/ray_runtime/config.py
+++ b/rinker/ray_runtime/config.py
@@ -1,0 +1,18 @@
+"""Configuration for the Ray runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RayRuntimeConfig:
+    """Configuration controlling Ray actor placement and behaviour."""
+
+    num_sampler_actors: int = 1
+    learner_num_gpus: float = 0.0
+    sampler_num_gpus: float = 0.0
+    reward_num_cpus: float = 0.0
+    max_inflight_rollouts: int = 8
+
+
+__all__ = ["RayRuntimeConfig"]

--- a/rinker/ray_runtime/runtime.py
+++ b/rinker/ray_runtime/runtime.py
@@ -1,0 +1,136 @@
+"""Runtime orchestration utilities for Ray based training."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, Deque, Iterable, List, Mapping, Sequence
+
+import torch
+import ray
+
+from ..core.types import AdamParams, Datum, ModelInput, SamplingParams
+from ..utils.futures import RayFuture
+from ..utils.tokenizer import SimpleTokenizer
+from .actors import ForwardBackwardPayload, LearnerActor, RewardActor, SamplerActor
+from .config import RayRuntimeConfig
+
+
+@dataclass
+class SamplingTaskResult:
+    """Container returned from sampler actors."""
+
+    text: str
+    token_ids: List[int]
+    logprobs: List[float]
+    parsed_response: str | None
+
+
+class RayRuntime:
+    """Manages Ray actors and mediates communication with the driver."""
+
+    def __init__(
+        self,
+        tokenizer: SimpleTokenizer,
+        config: RayRuntimeConfig,
+    ) -> None:
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, include_dashboard=False)
+        self._tokenizer = tokenizer
+        self._config = config
+        self._learner = LearnerActor.options(num_gpus=config.learner_num_gpus).remote(tokenizer.vocab_size)
+        self._samplers = [
+            SamplerActor.options(num_gpus=config.sampler_num_gpus).remote(tokenizer)
+            for _ in range(max(1, config.num_sampler_actors))
+        ]
+        self._next_sampler = 0
+        self._inflight_rollouts: Deque[ray.ObjectRef] = deque()
+        self._weights_version = 0
+
+    @property
+    def tokenizer(self) -> SimpleTokenizer:
+        return self._tokenizer
+
+    @property
+    def weights_version(self) -> int:
+        return self._weights_version
+
+    # ------------------------------------------------------------------
+    # Learner orchestration
+    # ------------------------------------------------------------------
+    def forward_backward(self, batch: Sequence[Datum], loss_fn: str) -> RayFuture[ForwardBackwardPayload]:
+        ref = self._learner.forward_backward.remote(batch, loss_fn)
+        return RayFuture(ref)
+
+    def forward_backward_custom(
+        self,
+        batch: Sequence[Datum],
+        loss_fn: Callable[[Sequence[Datum], torch.Tensor], object],
+    ) -> RayFuture[ForwardBackwardPayload]:
+        ref = self._learner.forward_backward_custom.remote(batch, loss_fn)
+        return RayFuture(ref)
+
+    def optim_step(self, params: AdamParams) -> RayFuture[Mapping[str, float]]:
+        ref = self._learner.optim_step.remote(params)
+        return RayFuture(ref)
+
+    def get_state(self) -> Mapping[str, torch.Tensor]:
+        return ray.get(self._learner.get_state.remote())
+
+    def refresh_sampler_weights(self) -> int:
+        state = self.get_state()
+        self.set_sampler_weights(state)
+        self._weights_version += 1
+        return self._weights_version
+
+    # ------------------------------------------------------------------
+    # Sampler orchestration
+    # ------------------------------------------------------------------
+    def set_sampler_weights(self, state_dict: Mapping[str, torch.Tensor]) -> None:
+        state_ref = ray.put(state_dict)
+        ray.get([sampler.set_weights.remote(state_ref) for sampler in self._samplers])
+
+    def sample(
+        self,
+        model_input: ModelInput,
+        sampling_params: SamplingParams,
+        num_samples: int,
+    ) -> List[SamplingTaskResult]:
+        sampler = self._acquire_sampler()
+        self._ensure_backpressure()
+        ref = sampler.generate.remote(model_input, sampling_params, num_samples)
+        self._inflight_rollouts.append(ref)
+        results: List[Mapping[str, object]] = ray.get(ref)
+        self._inflight_rollouts.remove(ref)
+        return [
+            SamplingTaskResult(
+                text=result["text"],
+                token_ids=list(result["token_ids"]),
+                logprobs=list(result["logprobs"]),
+                parsed_response=result.get("parsed_response"),
+            )
+            for result in results
+        ]
+
+    def _acquire_sampler(self) -> SamplerActor:
+        handle = self._samplers[self._next_sampler]
+        self._next_sampler = (self._next_sampler + 1) % len(self._samplers)
+        return handle
+
+    def _ensure_backpressure(self) -> None:
+        if len(self._inflight_rollouts) < self._config.max_inflight_rollouts:
+            return
+        ready, remaining = ray.wait(list(self._inflight_rollouts), num_returns=1)
+        self._inflight_rollouts = deque(remaining)
+
+    # ------------------------------------------------------------------
+    # Reward actor helpers
+    # ------------------------------------------------------------------
+    def create_reward_actors(self, reward_fns: Iterable[Callable[..., float]]) -> List[ray.ActorHandle]:
+        actors: List[ray.ActorHandle] = []
+        for fn in reward_fns:
+            actor = RewardActor.options(num_cpus=self._config.reward_num_cpus or None).remote(fn)
+            actors.append(actor)
+        return actors
+
+
+__all__ = ["RayRuntime", "SamplingTaskResult"]

--- a/rinker/tests/test_ray_runtime.py
+++ b/rinker/tests/test_ray_runtime.py
@@ -1,0 +1,43 @@
+import ray
+import torch
+
+from rinker.api.service_client import ServiceClient
+from rinker.core.types import AdamParams, Datum, ModelInput, SamplingParams
+from rinker.ray_runtime import RayRuntimeConfig
+
+
+def _build_batch(tokenizer):
+    prompt = "hi"
+    completion = " there"
+    tokens = torch.tensor(tokenizer.encode(prompt + completion), dtype=torch.long)
+    inputs = tokens[:-1]
+    targets = tokens[1:]
+    datum = Datum(
+        model_input=ModelInput(token_chunks=[inputs]),
+        loss_fn_inputs={
+            "targets": targets,
+            "weights": torch.ones_like(targets, dtype=torch.float32),
+        },
+    )
+    return [datum]
+
+
+def test_training_client_uses_ray_runtime():
+    config = RayRuntimeConfig(num_sampler_actors=1, max_inflight_rollouts=2)
+    service = ServiceClient(runtime_config=config)
+    base_model = service.get_server_capabilities().base_models[0]
+    training = service.create_lora_training_client(base_model, rank=4)
+    batch = _build_batch(training.tokenizer)
+
+    fb_future = training.forward_backward(batch, loss_fn="cross_entropy")
+    fb_result = fb_future.result()
+    assert fb_result.loss > 0
+
+    optim_metrics = training.optim_step(AdamParams(lr=1e-2)).result()
+    assert "grad_norm" in optim_metrics
+
+    sampler = training.save_weights_and_get_sampling_client("test-ray")
+    params = SamplingParams(max_new_tokens=4, temperature=0.8)
+    sample = sampler.sample(batch[0].model_input, params, num_samples=1)[0]
+    assert sample.text
+    ray.shutdown()

--- a/rinker/tests/test_sampling.py
+++ b/rinker/tests/test_sampling.py
@@ -1,5 +1,5 @@
 import torch
-
+import torch
 from rinker.api.sampling_client import SamplingClient
 from rinker.core.types import ModelInput, SamplingParams
 from rinker.utils.tokenizer import SimpleTokenizer

--- a/rinker/utils/futures.py
+++ b/rinker/utils/futures.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Callable, Generic, TypeVar
+
+import ray
 
 
 T = TypeVar("T")
@@ -16,4 +18,22 @@ class ImmediateFuture(Generic[T]):
         return self.value
 
 
-__all__ = ["ImmediateFuture"]
+class RayFuture(Generic[T]):
+    """Wrapper around a Ray ObjectRef that mimics the Future API."""
+
+    def __init__(self, ref: "ray.ObjectRef", transform: Callable[[object], T] | None = None) -> None:
+        self._ref = ref
+        self._transform = transform
+
+    @property
+    def object_ref(self) -> "ray.ObjectRef":
+        return self._ref
+
+    def result(self) -> T:
+        value = ray.get(self._ref)
+        if self._transform is not None:
+            return self._transform(value)
+        return value  # type: ignore[return-value]
+
+
+__all__ = ["ImmediateFuture", "RayFuture"]


### PR DESCRIPTION
## Summary
- introduce a Ray runtime package with learner, sampler, and reward actors plus GPU placement controls
- update the training and sampling clients to return Ray futures, sync sampler weights, and expose reward pools while preserving the public API
- add a Ray PPO example and integration tests covering Ray-backed training and sampling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df772496dc8332bc2356719ab40722