### PR TITLE
Add RL cookbook environment scaffolding and loops

### DIFF
--- a/rinker/recipes/__init__.py
+++ b/rinker/recipes/__init__.py
@@ -1,0 +1,1 @@
+"""High-level training recipes mirroring the Tinker cookbook."""

--- a/rinker/recipes/rl/__init__.py
+++ b/rinker/recipes/rl/__init__.py
@@ -1,0 +1,1 @@
+"""Reinforcement learning training loops."""

--- a/rinker/recipes/rl/train.py
+++ b/rinker/recipes/rl/train.py
@@ -1,0 +1,270 @@
+"""Performant RL training loop with group-centred advantages and KL shaping."""
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Sequence
+
+import torch
+
+from ...api.service_client import ServiceClient
+from ...core.engine import SimpleLanguageModel
+from ...core.types import AdamParams, Datum, ModelInput, SamplingParams
+from ...rl import Env, EnvAction, EnvGroupBuilder, EnvObservation, RLDataset
+from ...utils.seeding import seed_everything
+
+
+@dataclass
+class MathTask:
+    prompt: str
+    answer: str
+
+
+class MathEnv(Env):
+    """Deterministic environment rewarding exact arithmetic answers."""
+
+    def __init__(self, task: MathTask, tokenizer) -> None:
+        prompt_tokens = torch.tensor(tokenizer.encode(task.prompt), dtype=torch.long)
+        self._observation = EnvObservation(
+            model_input=ModelInput(token_chunks=[prompt_tokens]),
+            metadata={"prompt": task.prompt},
+        )
+        self._prompt = task.prompt
+        self._answer = task.answer
+
+    def initial_observation(self) -> EnvObservation:
+        return self._observation
+
+    def step(self, action: EnvAction):
+        text = action.text or ""
+        completion = text[len(self._prompt) :].strip()
+        reward = 1.0 if completion.startswith(self._answer) else 0.0
+        from ...rl.env import EnvStepResult
+
+        return EnvStepResult(
+            reward=reward,
+            done=True,
+            metrics={"is_correct": reward},
+        )
+
+
+def _reference_model(training_client) -> SimpleLanguageModel:
+    runtime = training_client._runtime  # type: ignore[attr-defined]
+    state_dict = runtime.get_state()
+    model = SimpleLanguageModel(runtime.tokenizer.vocab_size)
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def _sequence_logprobs(model: SimpleLanguageModel, token_ids: Sequence[int]) -> torch.Tensor:
+    if len(token_ids) <= 1:
+        return torch.empty(0, dtype=torch.float32)
+    with torch.no_grad():
+        inputs = torch.tensor(token_ids[:-1], dtype=torch.long).unsqueeze(0)
+        targets = torch.tensor(token_ids[1:], dtype=torch.long)
+        logits = model(inputs)
+        log_probs = torch.log_softmax(logits, dim=-1)
+        gathered = log_probs.gather(-1, targets.unsqueeze(0).unsqueeze(-1)).squeeze(0).squeeze(-1)
+        return gathered
+
+
+def _build_envs(tokenizer, tasks: Iterable[MathTask]) -> List[Env]:
+    return [MathEnv(task, tokenizer) for task in tasks]
+
+
+def _prepare_datum(
+    *,
+    sample,
+    prompt_tokens: torch.Tensor,
+) -> tuple[Datum, torch.Tensor, torch.Tensor]:
+    token_ids = torch.tensor(sample.token_ids, dtype=torch.long)
+    inputs = token_ids[:-1]
+    targets = token_ids[1:]
+    sampling_logprobs = torch.zeros_like(targets, dtype=torch.float32)
+    completion_start = prompt_tokens.numel() - 1
+    generated_logprobs = torch.tensor(sample.logprobs, dtype=torch.float32)
+    sampling_logprobs[
+        completion_start : completion_start + generated_logprobs.numel()
+    ] = generated_logprobs
+
+    datum = Datum(
+        model_input=ModelInput(token_chunks=[inputs]),
+        loss_fn_inputs={
+            "target_tokens": targets,
+            "sampling_logprobs": sampling_logprobs,
+            "advantages": torch.zeros_like(targets, dtype=torch.float32),
+            "clip_epsilon": 0.2,
+        },
+    )
+    mask = torch.zeros_like(targets, dtype=torch.bool)
+    mask[completion_start:] = True
+    return datum, mask, generated_logprobs
+
+
+def _kl_value(
+    *,
+    reference_logprobs: torch.Tensor,
+    generated_logprobs: torch.Tensor,
+    completion_start: int,
+) -> float:
+    if generated_logprobs.numel() == 0:
+        return 0.0
+    ref_slice = reference_logprobs[completion_start : completion_start + generated_logprobs.numel()]
+    if ref_slice.numel() != generated_logprobs.numel():
+        ref_slice = ref_slice[: generated_logprobs.numel()]
+    return float((generated_logprobs - ref_slice).sum().item())
+
+
+@dataclass
+class LoopConfig:
+    iterations: int
+    batch_size: int
+    group_size: int
+    num_substeps: int
+    beta_kl: float
+    loss_name: str
+    learning_rate: float
+
+
+class RLTrainer:
+    def __init__(self, *, training_client, reference_model: SimpleLanguageModel, config: LoopConfig) -> None:
+        self._training = training_client
+        self._reference_model = reference_model
+        self._config = config
+        self._optim = AdamParams(lr=config.learning_rate)
+
+    def run(self, builder: EnvGroupBuilder, sampling_params: SamplingParams) -> None:
+        for step in range(self._config.iterations):
+            dataset = RLDataset()
+            sampler = self._training.save_weights_and_get_sampling_client(f"rl-train-{step}")
+            groups = builder.build(self._config.batch_size)
+
+            start = time.time()
+            for group in groups:
+                prompt_tokens = group.observation.model_input.token_chunks[0]
+                results = sampler.sample(
+                    group.observation.model_input,
+                    sampling_params,
+                    num_samples=self._config.group_size,
+                )
+                for sample in results:
+                    datum, mask, generated_logprobs = _prepare_datum(
+                        sample=sample,
+                        prompt_tokens=prompt_tokens,
+                    )
+                    env_action = EnvAction(
+                        token_ids=sample.token_ids,
+                        logprobs=sample.logprobs,
+                        text=sample.text,
+                    )
+                    transition = group.env.step(env_action)
+                    ref_logprobs = _sequence_logprobs(self._reference_model, sample.token_ids)
+                    kl_val = _kl_value(
+                        reference_logprobs=ref_logprobs,
+                        generated_logprobs=generated_logprobs,
+                        completion_start=prompt_tokens.numel() - 1,
+                    )
+                    dataset.add_sample(
+                        group_id=group.group_index,
+                        datum=datum,
+                        reward=float(transition.reward),
+                        token_count=int(mask.sum().item()),
+                        advantage_mask=mask,
+                        kl_value=kl_val,
+                        metrics=transition.metrics,
+                    )
+            elapsed = time.time() - start
+
+            dataset.apply_kl_shaping(self._config.beta_kl)
+            dataset.apply_group_centered_advantages()
+
+            metrics = self._run_updates(dataset)
+
+            reward_mean = dataset.mean_reward()
+            reward_raw = dataset.mean_reward(shaped=False)
+            acceptance = dataset.acceptance_rate()
+            tokens_per_second = dataset.total_tokens / max(elapsed, 1e-6)
+            summary_metrics = dataset.metrics_summary()
+            kl_avg = dataset.average_kl()
+
+            print(
+                "step={step:03d} reward={reward:.3f} raw={raw:.3f} kl={kl:.4f} "
+                "accept={accept:.2f} tokens/s={tps:.1f} kl_q||p={kl_qp:.4f} "
+                "kl_p||q={kl_pq:.4f} clip={clip:.2f}".format(
+                    step=step,
+                    reward=reward_mean,
+                    raw=reward_raw,
+                    kl=kl_avg,
+                    accept=acceptance,
+                    tps=tokens_per_second,
+                    kl_qp=metrics.get("kl_q||p", 0.0),
+                    kl_pq=metrics.get("kl_p||q", 0.0),
+                    clip=metrics.get("clip_fraction", 0.0),
+                )
+            )
+            if summary_metrics:
+                extras = " ".join(f"{k}={v:.3f}" for k, v in sorted(summary_metrics.items()))
+                print(f"    metrics: {extras}")
+
+    def _run_updates(self, dataset: RLDataset) -> Mapping[str, float]:
+        batch = dataset.build_batch()
+        aggregated: Mapping[str, float] = {}
+        for substep in range(self._config.num_substeps):
+            fb = self._training.forward_backward(batch, loss_fn=self._config.loss_name).result()
+            self._training.optim_step(self._optim).result()
+            aggregated = fb.metrics
+        return aggregated
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="RL training loop with group advantages")
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--group-size", type=int, default=4)
+    parser.add_argument("--num-substeps", type=int, default=1)
+    parser.add_argument("--beta-kl", type=float, default=0.0)
+    parser.add_argument("--loss", type=str, default="ppo", choices=["ppo", "importance_sampling"])
+    parser.add_argument("--lr", type=float, default=5e-3)
+    parser.add_argument("--seed", type=int, default=1234)
+    args = parser.parse_args(argv)
+
+    seed_everything(args.seed)
+    service = ServiceClient()
+    base_model = service.get_server_capabilities().base_models[0]
+    training = service.create_lora_training_client(base_model, rank=4)
+    tokenizer = training.tokenizer
+
+    reference = _reference_model(training)
+
+    tasks = [
+        MathTask("1+1=", "2"),
+        MathTask("2+2=", "4"),
+        MathTask("3+3=", "6"),
+        MathTask("4+4=", "8"),
+        MathTask("5+5=", "10"),
+        MathTask("6+3=", "9"),
+        MathTask("7+2=", "9"),
+        MathTask("8+1=", "9"),
+    ]
+    envs = _build_envs(tokenizer, tasks)
+    builder = EnvGroupBuilder(envs)
+
+    config = LoopConfig(
+        iterations=args.iterations,
+        batch_size=args.batch_size,
+        group_size=args.group_size,
+        num_substeps=args.num_substeps,
+        beta_kl=args.beta_kl,
+        loss_name=args.loss,
+        learning_rate=args.lr,
+    )
+    trainer = RLTrainer(training_client=training, reference_model=reference, config=config)
+
+    sampling_params = SamplingParams(max_new_tokens=4, temperature=0.7)
+    trainer.run(builder, sampling_params)
+
+
+if __name__ == "__main__":
+    main()

--- a/rinker/recipes/rl_loop.py
+++ b/rinker/recipes/rl_loop.py
@@ -1,0 +1,177 @@
+"""Simple synchronous RL loop mirroring the Tinker cookbook example."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import List
+
+import torch
+
+from ..api.service_client import ServiceClient
+from ..core.engine import SimpleLanguageModel
+from ..core.types import AdamParams, Datum, ModelInput, SamplingParams
+from ..rl import Env, EnvAction, EnvGroupBuilder, EnvObservation, RLDataset
+from ..utils.seeding import seed_everything
+
+
+@dataclass
+class MathExample:
+    prompt: str
+    answer: str
+
+
+class MathQAEnv(Env):
+    """One-step environment that scores arithmetic answers."""
+
+    def __init__(self, example: MathExample, tokenizer) -> None:
+        prompt_tokens = torch.tensor(tokenizer.encode(example.prompt), dtype=torch.long)
+        self._observation = EnvObservation(model_input=ModelInput(token_chunks=[prompt_tokens]))
+        self._prompt = example.prompt
+        self._answer = example.answer
+
+    def initial_observation(self) -> EnvObservation:
+        return self._observation
+
+    def step(self, action: EnvAction):
+        text = action.text or ""
+        completion = text[len(self._prompt) :].strip()
+        reward = 1.0 if completion.startswith(self._answer) else 0.0
+        return self._terminal(reward)
+
+    def _terminal(self, reward: float):
+        from ..rl.env import EnvStepResult
+
+        return EnvStepResult(reward=reward, done=True, metrics={"is_correct": reward})
+
+
+def _compute_reference_model(training_client) -> SimpleLanguageModel:
+    runtime = training_client._runtime  # type: ignore[attr-defined]
+    state_dict = runtime.get_state()
+    model = SimpleLanguageModel(runtime.tokenizer.vocab_size)
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def _logprob_under(model: SimpleLanguageModel, token_ids: List[int]) -> torch.Tensor:
+    if len(token_ids) <= 1:
+        return torch.empty(0, dtype=torch.float32)
+    with torch.no_grad():
+        inputs = torch.tensor(token_ids[:-1], dtype=torch.long).unsqueeze(0)
+        targets = torch.tensor(token_ids[1:], dtype=torch.long)
+        logits = model(inputs)
+        log_probs = torch.log_softmax(logits, dim=-1)
+        gathered = log_probs.gather(-1, targets.unsqueeze(0).unsqueeze(-1)).squeeze(0).squeeze(-1)
+        return gathered
+
+
+def run_loop(
+    *,
+    batch_size: int = 4,
+    group_size: int = 4,
+    iterations: int = 12,
+    loss_name: str = "ppo",
+    beta_kl: float = 0.0,
+) -> None:
+    service = ServiceClient()
+    base_model = service.get_server_capabilities().base_models[0]
+    training = service.create_lora_training_client(base_model, rank=4)
+    tokenizer = training.tokenizer
+
+    reference_model = _compute_reference_model(training)
+
+    examples = [
+        MathExample("1+1=", "2"),
+        MathExample("2+2=", "4"),
+        MathExample("3+3=", "6"),
+        MathExample("1+2=", "3"),
+        MathExample("3+4=", "7"),
+        MathExample("4+5=", "9"),
+    ]
+    envs = [MathQAEnv(example, tokenizer) for example in examples]
+    builder = EnvGroupBuilder(envs)
+
+    sampling_params = SamplingParams(max_new_tokens=4, temperature=0.7)
+    optimiser = AdamParams(lr=5e-3)
+
+    for step in range(iterations):
+        dataset = RLDataset()
+        sampler = training.save_weights_and_get_sampling_client(f"simple-loop-{step}")
+        groups = builder.build(batch_size)
+
+        start = time.time()
+        for group in groups:
+            prompt_tokens = group.observation.model_input.token_chunks[0]
+            results = sampler.sample(group.observation.model_input, sampling_params, num_samples=group_size)
+            for sample in results:
+                token_ids = torch.tensor(sample.token_ids, dtype=torch.long)
+                inputs = token_ids[:-1]
+                targets = token_ids[1:]
+                sampling_logprobs = torch.zeros_like(targets, dtype=torch.float32)
+                completion_start = prompt_tokens.numel() - 1
+                generated_logprobs = torch.tensor(sample.logprobs, dtype=torch.float32)
+                sampling_logprobs[
+                    completion_start : completion_start + generated_logprobs.numel()
+                ] = generated_logprobs
+
+                datum = Datum(
+                    model_input=ModelInput(token_chunks=[inputs]),
+                    loss_fn_inputs={
+                        "target_tokens": targets,
+                        "sampling_logprobs": sampling_logprobs,
+                        "advantages": torch.zeros_like(targets, dtype=torch.float32),
+                        "clip_epsilon": 0.2,
+                    },
+                )
+
+                mask = torch.zeros_like(targets, dtype=torch.bool)
+                mask[completion_start:] = True
+
+                env_action = EnvAction(
+                    token_ids=sample.token_ids,
+                    logprobs=sample.logprobs,
+                    text=sample.text,
+                )
+                transition = group.env.step(env_action)
+
+                ref_logprobs = _logprob_under(reference_model, sample.token_ids)
+                ref_slice = ref_logprobs[
+                    completion_start : completion_start + generated_logprobs.numel()
+                ]
+                kl_value = float((generated_logprobs - ref_slice).sum().item())
+
+                dataset.add_sample(
+                    group_id=group.group_index,
+                    datum=datum,
+                    reward=float(transition.reward),
+                    token_count=int(mask.sum().item()),
+                    advantage_mask=mask,
+                    kl_value=kl_value,
+                    metrics=transition.metrics,
+                )
+        elapsed = time.time() - start
+
+        dataset.apply_kl_shaping(beta_kl)
+        dataset.apply_group_centered_advantages()
+
+        for substep in range(1):
+            fb = training.forward_backward(dataset.build_batch(), loss_fn=loss_name).result()
+            training.optim_step(optimiser).result()
+
+        reward_mean = dataset.mean_reward()
+        reward_raw = dataset.mean_reward(shaped=False)
+        tokens_per_second = dataset.total_tokens / max(elapsed, 1e-6)
+        acceptance = dataset.acceptance_rate()
+        kl_qp = fb.metrics.get("kl_q||p", 0.0)
+        kl_pq = fb.metrics.get("kl_p||q", 0.0)
+        clip_fraction = fb.metrics.get("clip_fraction", 0.0)
+        print(
+            f"step={step:02d} reward_mean={reward_mean:.3f} raw={reward_raw:.3f} "
+            f"kl_q||p={kl_qp:.4f} kl_p||q={kl_pq:.4f} "
+            f"accept={acceptance:.2f} clip={clip_fraction:.2f} tps={tokens_per_second:.1f}"
+        )
+
+
+if __name__ == "__main__":
+    seed_everything(1234)
+    run_loop()

--- a/rinker/rl/__init__.py
+++ b/rinker/rl/__init__.py
@@ -1,0 +1,17 @@
+"""Reinforcement learning utilities aligned with the Tinker cookbook semantics."""
+from .env import Env, EnvAction, EnvGroup, EnvGroupBuilder, EnvObservation, EnvStepResult
+from .dataset import RLDataset, RLSample
+from .utils import apply_kl_shaping, center_group_advantages
+
+__all__ = [
+    "Env",
+    "EnvAction",
+    "EnvGroup",
+    "EnvGroupBuilder",
+    "EnvObservation",
+    "EnvStepResult",
+    "RLDataset",
+    "RLSample",
+    "apply_kl_shaping",
+    "center_group_advantages",
+]

--- a/rinker/rl/dataset.py
+++ b/rinker/rl/dataset.py
@@ -1,0 +1,185 @@
+"""Dataset utilities for token-level reinforcement learning."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import torch
+
+from ..core.types import Datum
+
+
+@dataclass
+class RLSample:
+    """Container storing data for a single sampled trajectory."""
+
+    group_id: int
+    datum: Datum
+    reward: float
+    raw_reward: float
+    token_count: int
+    advantage_mask: torch.Tensor | None = None
+    kl_value: float | None = None
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+
+class RLDataset:
+    """Mutable dataset that accumulates samples across environment groups."""
+
+    def __init__(self) -> None:
+        self._samples: List[RLSample] = []
+
+    # ------------------------------------------------------------------
+    # Mutation helpers
+    # ------------------------------------------------------------------
+    def add_sample(
+        self,
+        *,
+        group_id: int,
+        datum: Datum,
+        reward: float,
+        token_count: int,
+        advantage_mask: torch.Tensor | None = None,
+        kl_value: float | None = None,
+        metrics: Mapping[str, float] | None = None,
+    ) -> None:
+        if advantage_mask is not None and not isinstance(advantage_mask, torch.Tensor):
+            raise TypeError("advantage_mask must be a torch.Tensor or None")
+        if advantage_mask is not None:
+            if advantage_mask.dtype != torch.bool:
+                raise TypeError("advantage_mask must be a boolean tensor")
+        sample = RLSample(
+            group_id=group_id,
+            datum=datum,
+            reward=reward,
+            raw_reward=reward,
+            token_count=int(token_count),
+            advantage_mask=advantage_mask,
+            kl_value=kl_value,
+            metrics=dict(metrics or {}),
+        )
+        self._samples.append(sample)
+
+    def extend(self, samples: Iterable[RLSample]) -> None:
+        for sample in samples:
+            self._samples.append(sample)
+
+    def clear(self) -> None:
+        self._samples.clear()
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    @property
+    def samples(self) -> Sequence[RLSample]:
+        return tuple(self._samples)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._samples
+
+    @property
+    def num_groups(self) -> int:
+        return len({sample.group_id for sample in self._samples})
+
+    @property
+    def num_samples(self) -> int:
+        return len(self._samples)
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(sample.token_count for sample in self._samples)
+
+    def mean_reward(self, *, shaped: bool = True) -> float:
+        rewards = [sample.reward if shaped else sample.raw_reward for sample in self._samples]
+        if not rewards:
+            return 0.0
+        return float(torch.tensor(rewards, dtype=torch.float32).mean().item())
+
+    def reward_std(self, *, shaped: bool = True) -> float:
+        rewards = [sample.reward if shaped else sample.raw_reward for sample in self._samples]
+        if not rewards:
+            return 0.0
+        return float(torch.tensor(rewards, dtype=torch.float32).std(unbiased=False).item())
+
+    def acceptance_rate(self, *, threshold: float = 0.0, shaped: bool = True) -> float:
+        if self.is_empty:
+            return 0.0
+        accepted = 0
+        for sample in self._samples:
+            reward = sample.reward if shaped else sample.raw_reward
+            if reward > threshold:
+                accepted += 1
+        return accepted / max(len(self._samples), 1)
+
+    def average_kl(self) -> float:
+        kl_values = [sample.kl_value for sample in self._samples if sample.kl_value is not None]
+        if not kl_values:
+            return 0.0
+        return float(torch.tensor(kl_values, dtype=torch.float32).mean().item())
+
+    # ------------------------------------------------------------------
+    # Advantage utilities
+    # ------------------------------------------------------------------
+    def apply_group_centered_advantages(self) -> None:
+        rewards_by_group: Dict[int, List[float]] = {}
+        for sample in self._samples:
+            rewards_by_group.setdefault(sample.group_id, []).append(sample.reward)
+
+        for group_id, rewards in rewards_by_group.items():
+            group_rewards = torch.tensor(rewards, dtype=torch.float32)
+            centred = group_rewards - group_rewards.mean()
+            centred_list = centred.tolist()
+            idx = 0
+            for sample in self._samples:
+                if sample.group_id != group_id:
+                    continue
+                advantage_value = centred_list[idx]
+                idx += 1
+                advantages_tensor = sample.datum.loss_fn_inputs.get("advantages")
+                if not isinstance(advantages_tensor, torch.Tensor):
+                    raise KeyError("Datum is missing an 'advantages' tensor")
+                if sample.advantage_mask is not None and sample.advantage_mask.shape != advantages_tensor.shape:
+                    raise ValueError("advantage_mask must match the 'advantages' tensor shape")
+                if sample.advantage_mask is None:
+                    advantages_tensor.fill_(advantage_value)
+                else:
+                    advantages_tensor[sample.advantage_mask] = advantage_value
+
+    # ------------------------------------------------------------------
+    # Reward shaping
+    # ------------------------------------------------------------------
+    def apply_kl_shaping(self, beta: float) -> None:
+        if beta <= 0:
+            return
+        for sample in self._samples:
+            if sample.kl_value is None:
+                sample.reward = sample.raw_reward
+            else:
+                sample.reward = sample.raw_reward - beta * sample.kl_value
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def build_batch(self) -> List[Datum]:
+        return [sample.datum for sample in self._samples]
+
+    def group_reward_summary(self) -> Dict[int, float]:
+        summary: Dict[int, float] = {}
+        for sample in self._samples:
+            summary.setdefault(sample.group_id, 0.0)
+            summary[sample.group_id] += sample.reward
+        return summary
+
+    def metrics_summary(self) -> Dict[str, float]:
+        aggregate: MutableMapping[str, List[float]] = {}
+        for sample in self._samples:
+            for key, value in sample.metrics.items():
+                aggregate.setdefault(key, []).append(float(value))
+        summary: Dict[str, float] = {}
+        for key, values in aggregate.items():
+            summary[key] = float(torch.tensor(values, dtype=torch.float32).mean().item())
+        return summary
+
+
+__all__ = ["RLDataset", "RLSample"]

--- a/rinker/rl/env.py
+++ b/rinker/rl/env.py
@@ -1,0 +1,128 @@
+"""Environment abstractions for token-level reinforcement learning."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Mapping, MutableSequence, Protocol, Sequence
+
+from ..core.types import ModelInput
+
+
+@dataclass
+class EnvObservation:
+    """Observation returned by an :class:`Env` prior to sampling.
+
+    The observation contains the token-level :class:`~rinker.core.types.ModelInput`
+    that should be passed to the sampler as well as optional metadata describing
+    the task. The metadata dictionary intentionally accepts arbitrary values so
+    that multi-modal environments (for example Qwen2.5-VL that requires image
+    tensors) can attach additional artefacts such as pixel buffers or bounding
+    boxes. Downstream code can forward these attachments to renderers or
+    sampler-side adaptors when vision models are used.
+    """
+
+    model_input: ModelInput
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    attachments: Mapping[str, Any] | None = None
+
+
+@dataclass
+class EnvAction:
+    """Action produced by a policy for a given observation.
+
+    The token ids, text, and per-token log-probabilities are optional to support
+    both textual and multi-modal completions. Vision models such as
+    Qwen2.5-VL emit text tokens conditioned on image features; the optional
+    ``metadata`` field allows callers to include the raw modality payload when
+    required by a downstream reward model.
+    """
+
+    token_ids: Sequence[int] | None = None
+    logprobs: Sequence[float] | None = None
+    text: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EnvStepResult:
+    """Outcome of :meth:`Env.step`."""
+
+    reward: float
+    done: bool = True
+    next_observation: EnvObservation | None = None
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+
+class Env(Protocol):
+    """Protocol implemented by reinforcement learning environments."""
+
+    def initial_observation(self) -> EnvObservation:
+        """Returns the first observation before any actions are taken."""
+
+    def step(self, action: EnvAction) -> EnvStepResult:
+        """Consumes an action and returns the resulting transition."""
+
+
+@dataclass
+class EnvGroup:
+    """Container representing a single environment within a batch."""
+
+    env: Env
+    observation: EnvObservation
+    group_index: int
+
+
+class EnvGroupBuilder:
+    """Utility to assemble batched environment groups for sampling.
+
+    The builder mirrors the grouping semantics from the Tinker cookbook: each
+    environment contributes one prompt to the batch and ``group_size`` rollouts
+    will later be sampled for that prompt. The builder rotates through the
+    provided environments when invoked repeatedly so that long-running training
+    loops can operate on datasets larger than ``batch_size`` without manual
+    book-keeping.
+    """
+
+    def __init__(self, envs: Iterable[Env]):
+        env_list = list(envs)
+        if not env_list:
+            raise ValueError("EnvGroupBuilder requires at least one environment")
+        self._envs: List[Env] = env_list
+        self._cursor: int = 0
+
+    def build(self, batch_size: int) -> List[EnvGroup]:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if batch_size > len(self._envs):
+            raise ValueError(
+                "batch_size cannot exceed the number of registered environments"
+            )
+        groups: List[EnvGroup] = []
+        for slot in range(batch_size):
+            env = self._envs[(self._cursor + slot) % len(self._envs)]
+            observation = env.initial_observation()
+            groups.append(EnvGroup(env=env, observation=observation, group_index=slot))
+        self._cursor = (self._cursor + batch_size) % len(self._envs)
+        return groups
+
+    def extend(self, envs: Iterable[Env]) -> None:
+        """Registers additional environments for future batches."""
+
+        additional: MutableSequence[Env] = list(envs)
+        if not additional:
+            return
+        self._envs.extend(additional)
+
+    def reset(self) -> None:
+        """Resets the rotation cursor, starting the next batch from the first env."""
+
+        self._cursor = 0
+
+
+__all__ = [
+    "Env",
+    "EnvAction",
+    "EnvGroup",
+    "EnvGroupBuilder",
+    "EnvObservation",
+    "EnvStepResult",
+]

--- a/rinker/rl/utils.py
+++ b/rinker/rl/utils.py
@@ -1,0 +1,39 @@
+"""Helper utilities for reinforcement learning loops."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import torch
+
+from .dataset import RLDataset
+
+
+def center_group_advantages(dataset: RLDataset) -> None:
+    """Applies group-centred advantages in-place.
+
+    This helper simply forwards to :meth:`RLDataset.apply_group_centered_advantages`
+    and exists for API parity with the Tinker cookbook where a standalone helper
+    is provided.
+    """
+
+    dataset.apply_group_centered_advantages()
+
+
+def apply_kl_shaping(rewards: Sequence[float], kl_values: Sequence[float], beta: float) -> torch.Tensor:
+    """Returns a shaped reward tensor ``r - beta * KL``.
+
+    The helper mirrors the reward-shaping guidance from the cookbook: users are
+    expected to subtract the KL penalty before advantages are computed rather
+    than mixing it into the PPO loss directly.
+    """
+
+    if beta <= 0 or not rewards:
+        return torch.tensor(rewards, dtype=torch.float32)
+    if len(rewards) != len(kl_values):
+        raise ValueError("rewards and kl_values must have matching lengths")
+    rewards_tensor = torch.tensor(rewards, dtype=torch.float32)
+    kl_tensor = torch.tensor(kl_values, dtype=torch.float32)
+    return rewards_tensor - beta * kl_tensor
+
+
+__all__ = ["apply_kl_shaping", "center_group_advantages"]


### PR DESCRIPTION
## Summary
- add Env/EnvGroup abstractions with a rotation builder to mirror the cookbook environment API and support multimodal prompts
- implement an RL dataset container with group-centred advantages, KL shaping hooks, and utility helpers for reuse
- add simple and performant RL training recipes that expose cookbook hyperparameters, apply KL shaping, and log PPO diagnostics

## Testing
- python -m rinker.recipes.rl_loop
- python -m rinker.recipes.rl.train --iterations 12 --batch-size 4 --group-size 4 --num-substeps 1
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68df8135a5bc8332aed624985738da1f