### PR TITLE
Add LoRA and async streaming capabilities to Ray runtime

### DIFF
--- a/rinker/api/sampling_client.py
+++ b/rinker/api/sampling_client.py
@@ -18,6 +18,7 @@ class SamplingResult:
     token_ids: List[int]
     logprobs: List[float]
     parsed_response: str | None = None
+    weights_version: int | None = None
 
 
 class SamplingClient:
@@ -67,6 +68,7 @@ class SamplingClient:
                 token_ids=result.token_ids,
                 logprobs=result.logprobs,
                 parsed_response=result.parsed_response,
+                weights_version=result.weights_version,
             )
             for result in results
         ]
@@ -97,7 +99,14 @@ class SamplingClient:
                 if self._should_stop(decoded, sampling_params):
                     break
             text = self._tokenizer.decode(token_ids)
-            results.append(SamplingResult(text=text, token_ids=token_ids, logprobs=generated_logprobs))
+            results.append(
+                SamplingResult(
+                    text=text,
+                    token_ids=token_ids,
+                    logprobs=generated_logprobs,
+                    weights_version=self._weights_version,
+                )
+            )
         return results
 
     def _select_token(self, logits: torch.Tensor, params: SamplingParams) -> tuple[int, float]:
@@ -137,6 +146,10 @@ class SamplingClient:
         if not params.stop_sequences:
             return False
         return any(decoded.endswith(stop) for stop in params.stop_sequences)
+
+    @property
+    def weights_version(self) -> int | None:
+        return self._weights_version
 
 
 __all__ = ["SamplingClient", "SamplingResult"]

--- a/rinker/api/service_client.py
+++ b/rinker/api/service_client.py
@@ -1,11 +1,12 @@
 """Entry point for users interacting with the Ray training runtime."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List
 
 from ..utils.tokenizer import SimpleTokenizer
 from ..ray_runtime import RayRuntime, RayRuntimeConfig
+from ..ray_runtime.config import StreamMinibatchConfig
 from .training_client import TrainingClient
 
 
@@ -34,6 +35,26 @@ class ServiceClient:
         if base_model not in self._base_models:
             raise ValueError(f"Unsupported base model: {base_model}")
         runtime_config = kwargs.pop("runtime_config", None) or self._runtime_config
+        updates: dict[str, object] = {"lora_rank": rank}
+        allowed = {
+            "lora_alpha",
+            "lora_dropout",
+            "amp_dtype",
+            "gradient_accumulation_steps",
+            "sampler_backend",
+            "max_steps_off_policy",
+            "stream_minibatch",
+        }
+        for key in list(kwargs.keys()):
+            if key not in allowed:
+                raise TypeError(f"Unexpected keyword argument '{key}'")
+            value = kwargs.pop(key)
+            if key == "stream_minibatch" and isinstance(value, dict):
+                value = StreamMinibatchConfig(**value)
+            updates[key] = value
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
+        runtime_config = replace(runtime_config, **updates)
         runtime = RayRuntime(tokenizer=self._tokenizer, config=runtime_config)
         return TrainingClient(runtime=runtime)
 

--- a/rinker/api/training_client.py
+++ b/rinker/api/training_client.py
@@ -2,18 +2,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Iterable, List, Mapping, Sequence, TYPE_CHECKING
+import warnings
 
 import torch
+import ray
 
 from ..core import engine
 from ..core.types import AdamParams, Datum
-from ..ray_runtime import RayRuntime
+from ..ray_runtime import RayRuntime, RayRuntimeConfig
+from ..ray_runtime.config import StreamMinibatchConfig
 from ..ray_runtime.actors import ForwardBackwardPayload
 from ..utils.futures import RayFuture
 from ..utils.tokenizer import SimpleTokenizer
 from .sampling_client import SamplingClient
 
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..rl.dataset import RLDataset
 
 @dataclass
 class ForwardBackwardResponse:
@@ -26,26 +31,33 @@ class TrainingClient:
     def __init__(self, *, runtime: RayRuntime) -> None:
         self._runtime = runtime
         self._tokenizer = runtime.tokenizer
+        self._max_steps_off_policy = runtime.config.max_steps_off_policy
 
     @property
     def tokenizer(self) -> SimpleTokenizer:
         return self._tokenizer
+
+    @property
+    def runtime_config(self) -> RayRuntimeConfig:
+        return self._runtime.config
 
     def forward_backward(
         self,
         batch: Sequence[Datum],
         loss_fn: str = "cross_entropy",
     ) -> RayFuture[ForwardBackwardResponse]:
-        payload_future = self._runtime.forward_backward(batch, loss_fn)
-        return RayFuture(payload_future.object_ref, self._build_response)
+        filtered = self._filter_off_policy_batch(batch)
+        payload_future = self._runtime.forward_backward(filtered, loss_fn)
+        return payload_future.with_transform(self._build_response)
 
     def forward_backward_custom(
         self,
         batch: Sequence[Datum],
         loss_fn: Callable[[Sequence[Datum], torch.Tensor], engine.CustomLossOutputs],
     ) -> RayFuture[ForwardBackwardResponse]:
-        payload_future = self._runtime.forward_backward_custom(batch, loss_fn)
-        return RayFuture(payload_future.object_ref, self._build_response)
+        filtered = self._filter_off_policy_batch(batch)
+        payload_future = self._runtime.forward_backward_custom(filtered, loss_fn)
+        return payload_future.with_transform(self._build_response)
 
     def optim_step(self, params: AdamParams) -> RayFuture[dict]:
         return self._runtime.optim_step(params)
@@ -57,6 +69,45 @@ class TrainingClient:
     def create_reward_actors(self, reward_fns: Iterable[Callable[..., float]]):
         return self._runtime.create_reward_actors(reward_fns)
 
+    def save_state(self) -> dict[str, object]:
+        state = self._runtime.save_state()
+        return dict(state)
+
+    def load_state(self, state: Mapping[str, object]) -> None:
+        self._runtime.load_state(state)
+
+    def export_lora_weights(self) -> Mapping[str, Mapping[str, torch.Tensor]]:
+        return self._runtime.export_for_hf()
+
+    def stream_minibatch_train(
+        self,
+        dataset: "RLDataset",
+        *,
+        loss_fn: str,
+        optimiser: AdamParams,
+        config: StreamMinibatchConfig | None = None,
+    ) -> List[ForwardBackwardResponse]:
+        if dataset.is_empty:
+            return []
+        schedule = config or self._runtime.config.stream_minibatch or StreamMinibatchConfig()
+        if schedule.groups_per_batch <= 0 or schedule.num_minibatches <= 0:
+            raise ValueError("StreamMinibatchConfig must have positive fields")
+        pending: List[RayFuture[ForwardBackwardResponse]] = []
+        responses: List[ForwardBackwardResponse] = []
+        max_pending = max(1, schedule.num_minibatches)
+        for minibatch in dataset.iter_minibatches(schedule):
+            future = self.forward_backward(minibatch, loss_fn=loss_fn)
+            pending.append(future)
+            if len(pending) >= max_pending:
+                completed = self._pop_ready_future(pending)
+                responses.append(completed.result())
+                self.optim_step(optimiser).result()
+        while pending:
+            completed = self._pop_ready_future(pending)
+            responses.append(completed.result())
+            self.optim_step(optimiser).result()
+        return responses
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -66,6 +117,51 @@ class TrainingClient:
             metrics=dict(payload.metrics),
             loss_fn_outputs=dict(payload.loss_fn_outputs),
         )
+
+    def _filter_off_policy_batch(self, batch: Sequence[Datum]) -> List[Datum]:
+        if self._max_steps_off_policy < 0:
+            return list(batch)
+        current_version = self._runtime.weights_version
+        allowed_min = max(0, current_version - self._max_steps_off_policy)
+        filtered: List[Datum] = []
+        discarded = 0
+        missing = 0
+        for datum in batch:
+            version = getattr(datum, "policy_version", None)
+            if version is None:
+                missing += 1
+                filtered.append(datum)
+                continue
+            if version < allowed_min:
+                discarded += 1
+                continue
+            filtered.append(datum)
+        if not filtered:
+            raise ValueError("All samples exceeded the max_steps_off_policy window")
+        if discarded:
+            warnings.warn(
+                f"Discarded {discarded} datums older than policy version {allowed_min}",
+                RuntimeWarning,
+            )
+        if missing:
+            warnings.warn(
+                "Datums missing policy_version metadata treated as current policy",
+                RuntimeWarning,
+            )
+        return filtered
+
+    def _pop_ready_future(
+        self, futures: List[RayFuture[ForwardBackwardResponse]]
+    ) -> RayFuture[ForwardBackwardResponse]:
+        if len(futures) == 1:
+            return futures.pop(0)
+        refs = [future.object_ref for future in futures]
+        ready_refs, _ = ray.wait(refs, num_returns=1)
+        ready_ref = ready_refs[0]
+        for idx, future in enumerate(futures):
+            if future.object_ref == ready_ref:
+                return futures.pop(idx)
+        raise RuntimeError("Failed to locate ready future")
 
 
 __all__ = ["TrainingClient", "ForwardBackwardResponse"]

--- a/rinker/core/lora.py
+++ b/rinker/core/lora.py
@@ -1,0 +1,101 @@
+"""Lightweight LoRA utilities used by the simple reference model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass(slots=True)
+class LoRAConfig:
+    """Configuration controlling low rank adapters."""
+
+    rank: int
+    alpha: float = 16.0
+    dropout: float = 0.0
+    target_modules: Tuple[str, ...] = ("head",)
+
+
+class LoRALinear(nn.Module):
+    """Wraps an ``nn.Linear`` layer with a trainable low-rank adapter."""
+
+    def __init__(self, base: nn.Linear, config: LoRAConfig) -> None:
+        super().__init__()
+        if config.rank <= 0:
+            raise ValueError("LoRA rank must be > 0")
+        self.base = base
+        self.rank = config.rank
+        self.scaling = config.alpha / float(config.rank)
+        self.dropout = nn.Dropout(config.dropout) if config.dropout > 0 else nn.Identity()
+        self.lora_a = nn.Parameter(torch.zeros(config.rank, base.in_features))
+        self.lora_b = nn.Parameter(torch.zeros(base.out_features, config.rank))
+        nn.init.kaiming_uniform_(self.lora_a, a=math.sqrt(5))
+        nn.init.zeros_(self.lora_b)
+        self.base.weight.requires_grad_(False)
+        if self.base.bias is not None:
+            self.base.bias.requires_grad_(False)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple delegation
+        base_out = self.base(inputs)
+        dropped = self.dropout(inputs)
+        lora_out = F.linear(dropped, self.lora_a)
+        lora_out = F.linear(lora_out, self.lora_b)
+        return base_out + self.scaling * lora_out
+
+
+def apply_lora(model: nn.Module, config: LoRAConfig) -> None:
+    """Injects LoRA adapters into the requested sub-modules of ``model``."""
+
+    if config.rank <= 0:
+        return
+    for name, module in model.named_modules():
+        if name.split(".")[-1] in config.target_modules and isinstance(module, nn.Linear):
+            parent, attr = _resolve_parent(model, name)
+            setattr(parent, attr, LoRALinear(module, config))
+
+
+def merge_lora_weights(model: nn.Module) -> dict[str, torch.Tensor]:
+    """Creates a ``state_dict`` where LoRA weights are merged into their bases."""
+
+    merged_state: dict[str, torch.Tensor] = {}
+    for key, value in model.state_dict().items():
+        merged_state[key] = value.detach().cpu()
+
+    for name, module in model.named_modules():
+        if not isinstance(module, LoRALinear):
+            continue
+        weight_key = f"{name}.base.weight"
+        bias_key = f"{name}.base.bias"
+        update = (module.lora_b @ module.lora_a) * module.scaling
+        merged_state[f"{name}.weight"] = module.base.weight.detach().cpu() + update.detach().cpu()
+        if bias_key in merged_state:
+            merged_state[f"{name}.bias"] = merged_state.pop(bias_key)
+        merged_state.pop(weight_key, None)
+        merged_state.pop(f"{name}.lora_a", None)
+        merged_state.pop(f"{name}.lora_b", None)
+    return merged_state
+
+
+def extract_lora_parameters(model: nn.Module) -> dict[str, torch.Tensor]:
+    """Returns a state dict containing only the LoRA adapter parameters."""
+
+    adapters = {}
+    for name, module in model.named_modules():
+        if isinstance(module, LoRALinear):
+            adapters[f"{name}.lora_a"] = module.lora_a.detach().cpu()
+            adapters[f"{name}.lora_b"] = module.lora_b.detach().cpu()
+    return adapters
+
+
+def _resolve_parent(model: nn.Module, qualified_name: str) -> tuple[nn.Module, str]:
+    parts = qualified_name.split(".")
+    parent = model
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    return parent, parts[-1]
+
+__all__ = ["LoRAConfig", "LoRALinear", "apply_lora", "merge_lora_weights", "extract_lora_parameters"]

--- a/rinker/core/types.py
+++ b/rinker/core/types.py
@@ -40,6 +40,7 @@ class Datum:
 
     model_input: ModelInput
     loss_fn_inputs: TensorDict
+    policy_version: int | None = None
 
 
 @dataclass

--- a/rinker/examples/rl_basic.py
+++ b/rinker/examples/rl_basic.py
@@ -68,7 +68,11 @@ def build_batch(
                 "advantages": advantages,
                 "clip_epsilon": clip_epsilon,
             }
-            datum = Datum(model_input=ModelInput(token_chunks=[inputs]), loss_fn_inputs=loss_inputs)
+            datum = Datum(
+                model_input=ModelInput(token_chunks=[inputs]),
+                loss_fn_inputs=loss_inputs,
+                policy_version=getattr(sample, "weights_version", None),
+            )
             group.append((reward, datum, completion_start))
 
         if not group:

--- a/rinker/ray_runtime/__init__.py
+++ b/rinker/ray_runtime/__init__.py
@@ -1,6 +1,6 @@
 """Ray runtime integration for Rinker."""
 from .actors import LearnerActor, SamplerActor, RewardActor
-from .config import RayRuntimeConfig
+from .config import RayRuntimeConfig, StreamMinibatchConfig
 from .runtime import RayRuntime, SamplingTaskResult
 
 __all__ = [
@@ -9,5 +9,6 @@ __all__ = [
     "RewardActor",
     "RayRuntime",
     "RayRuntimeConfig",
+    "StreamMinibatchConfig",
     "SamplingTaskResult",
 ]

--- a/rinker/ray_runtime/config.py
+++ b/rinker/ray_runtime/config.py
@@ -5,6 +5,14 @@ from dataclasses import dataclass
 
 
 @dataclass(slots=True)
+class StreamMinibatchConfig:
+    """Configuration describing the streaming minibatch schedule."""
+
+    groups_per_batch: int = 1
+    num_minibatches: int = 1
+
+
+@dataclass(slots=True)
 class RayRuntimeConfig:
     """Configuration controlling Ray actor placement and behaviour."""
 
@@ -13,6 +21,31 @@ class RayRuntimeConfig:
     sampler_num_gpus: float = 0.0
     reward_num_cpus: float = 0.0
     max_inflight_rollouts: int = 8
+    sampler_backend: str = "torch"
+    lora_rank: int = 8
+    lora_alpha: float = 16
+    lora_dropout: float = 0.05
+    amp_dtype: str | None = None
+    gradient_accumulation_steps: int = 1
+    max_steps_off_policy: int = 0
+    stream_minibatch: StreamMinibatchConfig | None = None
+
+    def learner_kwargs(self) -> dict[str, object]:
+        return {
+            "lora_rank": self.lora_rank,
+            "lora_alpha": self.lora_alpha,
+            "lora_dropout": self.lora_dropout,
+            "amp_dtype": self.amp_dtype,
+            "gradient_accumulation_steps": self.gradient_accumulation_steps,
+        }
+
+    def sampler_kwargs(self) -> dict[str, object]:
+        return {
+            "lora_rank": self.lora_rank,
+            "lora_alpha": self.lora_alpha,
+            "lora_dropout": self.lora_dropout,
+            "backend": self.sampler_backend,
+        }
 
 
-__all__ = ["RayRuntimeConfig"]
+__all__ = ["RayRuntimeConfig", "StreamMinibatchConfig"]

--- a/rinker/ray_runtime/runtime.py
+++ b/rinker/ray_runtime/runtime.py
@@ -7,6 +7,7 @@ from typing import Callable, Deque, Iterable, List, Mapping, Sequence
 
 import torch
 import ray
+from ray.exceptions import RayActorError
 
 from ..core.types import AdamParams, Datum, ModelInput, SamplingParams
 from ..utils.futures import RayFuture
@@ -23,6 +24,41 @@ class SamplingTaskResult:
     token_ids: List[int]
     logprobs: List[float]
     parsed_response: str | None
+    weights_version: int
+
+
+class _ResilientRayFuture(RayFuture):
+    """Future wrapper that restarts the learner actor on failure."""
+
+    def __init__(
+        self,
+        runtime: "RayRuntime",
+        method_name: str,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        transform: Callable[[object], object] | None = None,
+    ) -> None:
+        self._runtime = runtime
+        self._method_name = method_name
+        self._args = tuple(args)
+        self._kwargs = dict(kwargs)
+        ref = runtime._invoke_learner(method_name, *args, **kwargs)
+        super().__init__(ref, transform)
+
+    def result(self):  # type: ignore[override]
+        try:
+            return super().result()
+        except RayActorError:
+            self._runtime._restart_learner()
+            self._ref = self._runtime._invoke_learner(
+                self._method_name, *self._args, **self._kwargs
+            )
+            return super().result()
+
+    def with_transform(self, transform: Callable[[object], object]):
+        self._transform = transform
+        return self
 
 
 class RayRuntime:
@@ -37,14 +73,20 @@ class RayRuntime:
             ray.init(ignore_reinit_error=True, include_dashboard=False)
         self._tokenizer = tokenizer
         self._config = config
-        self._learner = LearnerActor.options(num_gpus=config.learner_num_gpus).remote(tokenizer.vocab_size)
+        self._config = config
+        self._learner = LearnerActor.options(num_gpus=config.learner_num_gpus).remote(
+            tokenizer.vocab_size, **config.learner_kwargs()
+        )
         self._samplers = [
-            SamplerActor.options(num_gpus=config.sampler_num_gpus).remote(tokenizer)
+            SamplerActor.options(num_gpus=config.sampler_num_gpus).remote(
+                tokenizer, **config.sampler_kwargs()
+            )
             for _ in range(max(1, config.num_sampler_actors))
         ]
         self._next_sampler = 0
         self._inflight_rollouts: Deque[ray.ObjectRef] = deque()
         self._weights_version = 0
+        self._last_checkpoint: Mapping[str, object] | None = None
 
     @property
     def tokenizer(self) -> SimpleTokenizer:
@@ -54,33 +96,51 @@ class RayRuntime:
     def weights_version(self) -> int:
         return self._weights_version
 
+    @property
+    def config(self) -> RayRuntimeConfig:
+        return self._config
+
     # ------------------------------------------------------------------
     # Learner orchestration
     # ------------------------------------------------------------------
     def forward_backward(self, batch: Sequence[Datum], loss_fn: str) -> RayFuture[ForwardBackwardPayload]:
-        ref = self._learner.forward_backward.remote(batch, loss_fn)
-        return RayFuture(ref)
+        return _ResilientRayFuture(self, "forward_backward", (batch, loss_fn), {})
 
     def forward_backward_custom(
         self,
         batch: Sequence[Datum],
         loss_fn: Callable[[Sequence[Datum], torch.Tensor], object],
     ) -> RayFuture[ForwardBackwardPayload]:
-        ref = self._learner.forward_backward_custom.remote(batch, loss_fn)
-        return RayFuture(ref)
+        return _ResilientRayFuture(
+            self,
+            "forward_backward_custom",
+            (batch, loss_fn),
+            {},
+        )
 
     def optim_step(self, params: AdamParams) -> RayFuture[Mapping[str, float]]:
-        ref = self._learner.optim_step.remote(params)
-        return RayFuture(ref)
+        return _ResilientRayFuture(self, "optim_step", (params,), {})
 
     def get_state(self) -> Mapping[str, torch.Tensor]:
-        return ray.get(self._learner.get_state.remote())
+        return self._call_learner_sync("get_state")
 
     def refresh_sampler_weights(self) -> int:
         state = self.get_state()
         self.set_sampler_weights(state)
         self._weights_version += 1
         return self._weights_version
+
+    def export_for_hf(self) -> Mapping[str, Mapping[str, torch.Tensor]]:
+        return self._call_learner_sync("export_for_hf")
+
+    def save_state(self) -> Mapping[str, object]:
+        checkpoint = self._call_learner_sync("save_state")
+        self._last_checkpoint = checkpoint
+        return checkpoint
+
+    def load_state(self, state: Mapping[str, object]) -> None:
+        self._last_checkpoint = dict(state)
+        self._call_learner_sync("load_state", state)
 
     # ------------------------------------------------------------------
     # Sampler orchestration
@@ -99,7 +159,14 @@ class RayRuntime:
         self._ensure_backpressure()
         ref = sampler.generate.remote(model_input, sampling_params, num_samples)
         self._inflight_rollouts.append(ref)
-        results: List[Mapping[str, object]] = ray.get(ref)
+        try:
+            results: List[Mapping[str, object]] = ray.get(ref)
+        except RayActorError:
+            self._inflight_rollouts.remove(ref)
+            sampler = self._restart_sampler(sampler)
+            ref = sampler.generate.remote(model_input, sampling_params, num_samples)
+            self._inflight_rollouts.append(ref)
+            results = ray.get(ref)
         self._inflight_rollouts.remove(ref)
         return [
             SamplingTaskResult(
@@ -107,6 +174,7 @@ class RayRuntime:
                 token_ids=list(result["token_ids"]),
                 logprobs=list(result["logprobs"]),
                 parsed_response=result.get("parsed_response"),
+                weights_version=self._weights_version,
             )
             for result in results
         ]
@@ -121,6 +189,38 @@ class RayRuntime:
             return
         ready, remaining = ray.wait(list(self._inflight_rollouts), num_returns=1)
         self._inflight_rollouts = deque(remaining)
+
+    def _invoke_learner(self, method: str, *args, **kwargs) -> ray.ObjectRef:
+        return getattr(self._learner, method).remote(*args, **kwargs)
+
+    def _call_learner_sync(self, method: str, *args, **kwargs):
+        ref = self._invoke_learner(method, *args, **kwargs)
+        try:
+            return ray.get(ref)
+        except RayActorError:
+            self._restart_learner()
+            ref = self._invoke_learner(method, *args, **kwargs)
+            return ray.get(ref)
+
+    def _restart_learner(self) -> None:
+        self._learner = LearnerActor.options(num_gpus=self._config.learner_num_gpus).remote(
+            self._tokenizer.vocab_size, **self._config.learner_kwargs()
+        )
+        if self._last_checkpoint is not None:
+            self._call_learner_sync("load_state", self._last_checkpoint)
+
+    def _restart_sampler(self, sampler: SamplerActor) -> SamplerActor:
+        index = self._samplers.index(sampler)
+        new_sampler = SamplerActor.options(num_gpus=self._config.sampler_num_gpus).remote(
+            self._tokenizer, **self._config.sampler_kwargs()
+        )
+        self._samplers[index] = new_sampler
+        if self._last_checkpoint is not None:
+            state = self._last_checkpoint.get("model")
+            if isinstance(state, Mapping):
+                state_ref = ray.put(state)
+                ray.get(new_sampler.set_weights.remote(state_ref))
+        return new_sampler
 
     # ------------------------------------------------------------------
     # Reward actor helpers

--- a/rinker/recipes/rl_loop.py
+++ b/rinker/recipes/rl_loop.py
@@ -122,6 +122,7 @@ def run_loop(
                         "advantages": torch.zeros_like(targets, dtype=torch.float32),
                         "clip_epsilon": 0.2,
                     },
+                    policy_version=getattr(sample, "weights_version", None),
                 )
 
                 mask = torch.zeros_like(targets, dtype=torch.bool)
@@ -148,6 +149,7 @@ def run_loop(
                     advantage_mask=mask,
                     kl_value=kl_value,
                     metrics=transition.metrics,
+                    policy_version=getattr(sample, "weights_version", None),
                 )
         elapsed = time.time() - start
 


### PR DESCRIPTION
## Summary
- integrate configurable LoRA adapters, AMP, and gradient accumulation into the learner and sampler actors
- add streaming minibatch scheduling, off-policy guarding, and Ray actor restart logic to the runtime and dataset utilities
- expose LoRA export helpers and extend tests/examples to exercise the new training and sampling flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df886e340483329def2891b4ebc5b1